### PR TITLE
post reqs first attempt

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,30 +80,86 @@ Let's imagine that that username and password you've set are simply "voyages"/"v
 
 The full authentication workflow would look like:
 
-```
-import requests
-import json
-url='http://127.0.0.1:8000/voyages2022_auth_endpoint/'
-r=requests.post(url,{'username':'voyages','password':'voyages'})
-token=json.loads(r.text)['token']
 
-headers={'Authorization':'Token %s' %token}
+	import requests
+	import json
+	url='http://127.0.0.1:8000/voyages2022_auth_endpoint/'
+	r=requests.post(url,{'username':'voyages','password':'voyages'})
+	token=json.loads(r.text)['token']
 
-print(headers)
+	headers={'Authorization':'Token %s' %token}
 
-url='http://127.0.0.1:8000/voyage/'
-r=requests.get(url,headers=headers)
-```
+	print(headers)
 
-### 1. Request People, Voyages, Places, Estimates, or an Autocompletion
+	url='http://127.0.0.1:8000/voyage/'
+	r=requests.get(url,headers=headers)
+
+
+### 1. POST Requests
+
+March 31: Enabled POST requests
+
+Why?
+
+* This will allow for the construction of more complex queries
+* For instance, it allows us to use the autocomplete endpoint to turn inexact text searches into precise selectors
+
+How does it differ from GET requests documented below?
+
+* As little as possible :)
+* Values should simply be passed wrapped as arrays
+* With the one exception that inexact text matching has been deprecated in favor of exact matching of arrayed values
+
+So a request to PAST asking of people transported on voyages with Voyage ID's between 2314 and 2500 would look like
+	
+	POST http://127.0.0.1:8000/past/
+	
+	Body:
+	{
+		'hierarchical': ['false'],
+		'results_page': ['3'],
+		'results_per_page': ['20'],
+		'voyage__voyage_id': ['2314,2500']
+	}
+	
+And would return results 60-79 of 21,867 total records.
+
+
+Or, to use the exact text with autocomplete as hinted at above, you might send the following request
+
+	POST http://127.0.0.1:8000/voyage/autocomplete
+
+	Body:
+	{'voyage_itinerary__imp_principal_region_slave_dis__region': 'jam'}
+
+And get back
+
+	{
+		"voyage_itinerary__imp_principal_region_slave_dis__region": [
+			"Jamaica"
+		]
+	}
+
+Then feed that precise value into that variable:
+
+	POST http://127.0.0.1:8000/voyage/
+	
+	Body:
+	{	'voyage_itinerary__imp_principal_region_slave_dis__region':
+		['Barbados','Jamaica']
+	}
+
+And get back 5,816 results.
+
+
+### 2. Request People, Voyages, Places, Estimates, or an Autocompletion
 
 1. People: GET http://127.0.0.1:8000/past
 1. Voyages: GET http://127.0.0.1:8000/voyage
 1. Places: GET http://127.0.0.1:8000/voyage/geo
 1. Estimates:  GET http://127.0.0.1:8000/assessment
 
-```
-'imp_broad_region_voyage_begin':
+	'imp_broad_region_voyage_begin':
 	{
 	'broad_region': 'Brazil',
 	'id': 6,
@@ -112,9 +168,8 @@ r=requests.get(url,headers=headers)
 	'show_on_map': True,
 	'value': 50000
 	},	
-```
 
-Autocomplete
+#### 2a. Autocomplete
 
 1. accepts a request
 	1. for one field
@@ -127,26 +182,23 @@ example: GET http://127.0.0.1:8000/voyage/autocomplete?voyage_captainconnection_
 
 Looks like:
 
-```
-{"voyage_captainconnection__captain__name":
-	[
-		"Dias, Manoel José",
-		"Mata, José Maria da",
-		"Ferreira, José dos Santos",
-		"Amorim, José Gomes de",
-		"Santos, Félix José dos",
-		"Teodoro, Teotônio José",
-		"Castro, Alexandre José de",
-		"Teixeira, José de Souza",
-		"Oliveira, José Malaquias de",
-		"Gomes, Manoel José"
-	],
-	"results_count": 8207
-}
-```
+	{"voyage_captainconnection__captain__name":
+		[
+			"Dias, Manoel José",
+			"Mata, José Maria da",
+			"Ferreira, José dos Santos",
+			"Amorim, José Gomes de",
+			"Santos, Félix José dos",
+			"Teodoro, Teotônio José",
+			"Castro, Alexandre José de",
+			"Teixeira, José de Souza",
+			"Oliveira, José Malaquias de",
+			"Gomes, Manoel José"
+		],
+		"results_count": 8207
+	}
 
-
-### 2. Get a list of the variables available to you, and their labels and data types
+### 3. Get a list of the variables available to you, and their labels and data types
 
 1. People: ```OPTIONS http://127.0.0.1:8000/past?hierarchical=False```
 1. Voyages: ```OPTIONS http://127.0.0.1:8000/voyage?hierarchical=False```
@@ -155,13 +207,13 @@ Looks like:
 
 This looks like:
 
-```
-'transactions__transaction__voyage__voyage_itinerary__imp_port_voyage_begin__region__latitude':
-	{
-	'label': 'Latitude of point',
-	'type': '<class "rest_framework.fields.DecimalField>"
-	}
-```
+
+	'transactions__transaction__voyage__voyage_itinerary__imp_port_voyage_begin__region__latitude':
+		{
+		'label': 'Latitude of point',
+		'type': '<class "rest_framework.fields.DecimalField>"
+		}
+
 
 Why "hierarchical=False"?
 
@@ -170,7 +222,7 @@ Why "hierarchical=False"?
 1. The django syntax for those links is a double underscore: "__"
 1. Coders are telling me it's easier to use the fully-qualified name of the variable rather than piecing it together
 
-### 3a. Filter, Sort, Order_by on any of these variables
+### 3a. Filter and sort on any of these variables
 
 1. GET http://127.0.0.1:8000/voyage?voyage_dates__imp_arrival_at_port_of_dis_yyyy=1800,1810
 1. GET http://127.0.0.1:8000/voyage/?voyage_itinerary__imp_principal_region_slave_dis__region=Barbados&voyage_dates__imp_arrival_at_port_of_dis_yyyy=1800,1850&selected_fields=voyage_dates__imp_arrival_at_port_of_dis_yyyy,voyage_slaves_numbers__imp_total_num_slaves_embarked,voyage_itinerary__imp_port_voyage_begin__place,voyage_ship_owner__name,voyage_itinerary__imp_principal_region_slave_dis__region&results_page=2&order_by=voyage_dates__imp_arrival_at_port_of_dis_yyyy,voyage_itinerary__imp_port_voyage_begin__name,voyage_itinerary__imp_port_voyage_begin__longitude
@@ -192,26 +244,25 @@ e.g., ```GET http://127.0.0.1:8000/voyage/aggregations?aggregate_fields=voyage_s
 
 Looks like:
 
-```
-{
-"voyage_slaves_numbers__imp_total_num_slaves_embarked":
 	{
-	"sum": 11264030,
-	"avg": 181.3269,
-	"min": 0,
-	"max": 2024,
-	"stddev": 186.44502407088743
-	},
-"voyage_slaves_numbers__imp_total_num_slaves_disembarked":
-	{
-	"sum": 9776588,
-	"avg": 158.1281,
-	"min": 0,
-	"max": 1700,
-	"stddev": 163.52181290079272
+	"voyage_slaves_numbers__imp_total_num_slaves_embarked":
+		{
+		"sum": 11264030,
+		"avg": 181.3269,
+		"min": 0,
+		"max": 2024,
+		"stddev": 186.44502407088743
+		},
+	"voyage_slaves_numbers__imp_total_num_slaves_disembarked":
+		{
+		"sum": 9776588,
+		"avg": 158.1281,
+		"min": 0,
+		"max": 1700,
+		"stddev": 163.52181290079272
+		}
 	}
-}
-```
+
 
 ### 4. Paginate
 
@@ -227,34 +278,33 @@ e.g., GET http://127.0.0.1:8000/voyage/dataframes?&voyage_dates__imp_arrival_at_
 
 Looks like:
 
-```
-{   'voyage_itinerary__first_landing_place__place':
-	[
-		'Barbados, port unspecified',
-		'Freetown',
-		'Freetown',
-		...
-	],
-	'voyage_itinerary__first_landing_region__region':
-	[
-		'Barbados',
-		'Sierra Leone',
-		'Sierra Leone',
-		...
-	],
-	'voyage_itinerary__imp_broad_region_voyage_begin__broad_region':
-	[
-		'Mainland North America',
-		None,
-		None,
-		...
-	],
-	'voyage_slaves_numbers__imp_total_num_slaves_embarked':
-	[
-		168,
-		130,
-		68,
-		...
-	]
-}
-```
+	{   'voyage_itinerary__first_landing_place__place':
+		[
+			'Barbados, port unspecified',
+			'Freetown',
+			'Freetown',
+			...
+		],
+		'voyage_itinerary__first_landing_region__region':
+		[
+			'Barbados',
+			'Sierra Leone',
+			'Sierra Leone',
+			...
+		],
+		'voyage_itinerary__imp_broad_region_voyage_begin__broad_region':
+		[
+			'Mainland North America',
+			None,
+			None,
+			...
+		],
+		'voyage_slaves_numbers__imp_total_num_slaves_embarked':
+		[
+			168,
+			130,
+			68,
+			...
+		]
+	}
+

--- a/src/tools/reqs.py
+++ b/src/tools/reqs.py
@@ -1,13 +1,175 @@
 import pprint
 import urllib
-from django.db.models import Avg,Sum,Min,Max,Count
+from django.db.models import Avg,Sum,Min,Max,Count,Q
 from django.db.models.aggregates import StdDev
 from .nest import *
 
-#GENERIC FUNCTION TO RUN A GET CALL ON REST SERIALIZERS
+#GENERIC FUNCTION TO RUN A CALL ON REST SERIALIZERS
 ##Default is to auto prefetch, but need to be able to turn it off.
 ##For instance, on our PAST graph-like data, the prefetch can overwhelm the system if you try to get everything
 ##can also just pass an array of prefetch vars
+
+
+def post_req(queryset,s,r,options_dict,auto_prefetch=True,retrieve_all=False):
+	
+	params=dict(r.POST)
+	pp = pprint.PrettyPrinter(indent=4)
+	print("--post req params--")
+	pp.pprint(params)
+		
+	#SELECT SPECIFIC FIELDS TO RETURN
+	selected_fields=params.get('selected_fields')
+	
+	if selected_fields is None:
+		selected_fields=[]
+	
+	#INCLUDE AGGREGATION FIELDS
+	aggregations_param=params.get('aggregate_fields')
+	
+	if aggregations_param is not None:
+		valid_aggregation_fields=[f for f in options_dict if 'Integer' in options_dict[f]['type'] or 'Decimal' in options_dict[f]['type']]
+		aggregation_fields=[f for f in aggregations_param if f in valid_aggregation_fields]
+		selected_fields=[]
+		auto_prefetch=False
+	else:
+		aggregation_fields=[]
+	
+	all_fields={i:options_dict[i] for i in options_dict if 'type' in options_dict[i]}
+	active_fields=list(set([i for i in params]+selected_fields+aggregation_fields).intersection(set(all_fields)))
+	
+	#ORDER RESULTS
+	order_by=params.get('order_by')
+	if order_by is not None:
+		print('--order by--')
+		print(order_by)
+		queryset=queryset.order_by(*order_by)
+	
+	###FILTER RESULTS
+	##select text and numeric fields, ignoring those without a type
+	text_fields=[i for i in all_fields if 'CharField' in all_fields[i]['type']]
+	numeric_fields=[i for i in all_fields if 'IntegerField' in all_fields[i]['type'] or 'DecimalField' in all_fields[i]['type'] or 'FloatField' in all_fields[i]['type']]
+	boolean_fields=[i for i in all_fields if 'BooleanField' in all_fields[i]['type']]
+	
+	##build filters
+	kwargs={}
+	###numeric filters -- only accepting one range per field right now
+	active_numeric_search_fields=[i for i in set(params).intersection(set(numeric_fields))]
+	if len(active_numeric_search_fields)>0:
+		for field in active_numeric_search_fields:
+			range=params.get(field)[0]
+			vals=[float(i) for i in range.split(',')]
+			vals.sort()
+			min,max=vals
+			kwargs['{0}__{1}'.format(field, 'lte')]=max
+			kwargs['{0}__{1}'.format(field, 'gte')]=min
+	###text filters (exact match, and allow for multiple entries joined by an or)
+	###this hard eval is not ideal but I can't quite see how else to do it just now?
+	active_text_search_fields=[i for i in set(params).intersection(set(text_fields))]
+	if len(active_text_search_fields)>0:
+		for field in active_text_search_fields:
+			vals=params.get(field)
+			qobjstrs=["Q(%s='%s')" %(field,val) for val in vals]
+			queryset=queryset.filter(eval('|'.join(qobjstrs)))
+	##boolean filters -- only accepting one range per field right now
+	active_boolean_search_fields=[i for i in set(params).intersection(set(boolean_fields))]
+	if len(active_boolean_search_fields)>0:
+		for field in active_boolean_search_fields:
+			searchstring=params.get(field)
+			if searchstring.lower() in ["true","t","1","yes"]:
+				searchstring=True
+			elif searchstring.lower() in ["false","f","0","no"]:
+				searchstring=False
+			
+			if searchstring in [True,False]:
+				kwargs[field]=searchstring
+	
+	###apply filters
+	queryset=queryset.filter(**kwargs)
+	results_count=queryset.count()
+	print('--counts--')
+	print("resultset size:",results_count)
+	
+	#PREFETCH REQUISITE FIELDS
+	if auto_prefetch:
+		prefetch_keys=list(options_dict.keys())
+	else:
+		prefetch_keys = active_fields
+	
+	#print(prefetch_keys)
+	##ideally, I'd run this list against the model and see
+	##which were m2m relationships (prefetch_related) and which were 1to1 (select_related)
+	prefetch_vars=list(set(['__'.join(i.split('__')[:-1]) for i in prefetch_keys if '__' in i]))
+	for p in prefetch_vars:
+		queryset=queryset.prefetch_related(p)
+	print('--prefetching %d vars--' %len(prefetch_vars))
+	#print(prefetch_vars)
+	
+	#AGGREGATIONS
+	##e.g. voyage_slaves_numbers__imp_total_num_slaves_embarked__sum
+	aggregations_param=params.get('aggregate_fields')
+	
+	if aggregation_fields != []:
+		aggqueryset=[]
+		selected_fields=[]
+		for aggfield in aggregation_fields:
+			for aggsuffix in ["sum","avg","min","max","count","stddev"]:
+				selected_fields.append(aggfield+"_"+aggsuffix)
+			aggqueryset.append(queryset.aggregate(Sum(aggfield)))
+			aggqueryset.append(queryset.aggregate(Avg(aggfield)))
+			aggqueryset.append(queryset.aggregate(Min(aggfield)))
+			aggqueryset.append(queryset.aggregate(Max(aggfield)))
+			aggqueryset.append(queryset.aggregate(Max(aggfield)))
+			aggqueryset.append(queryset.aggregate(StdDev(aggfield)))
+		queryset=aggqueryset
+		
+	#PAGINATION/LIMITS
+	if retrieve_all==False:
+		default_results_per_page=10
+		results_per_page=params.get('results_per_page')
+		if results_per_page==None:
+			results_per_page=default_results_per_page
+		else:
+			results_per_page=int(results_per_page[0])
+		results_page=params.get('results_page')
+		def urlunencode(d):
+			d2=dict(d)
+			for k in d:
+				d2[k]=str(d[k])
+			return(d2)
+		if results_page==None or results_page=='':
+			results_page=1
+			prev_uri=None
+			next_dict=urlunencode(params)
+			urlunencode(next_dict)
+			next_dict['results_page']=2
+			next_uri='?'.join([r.build_absolute_uri('?'),urllib.parse.urlencode(next_dict)])
+		else:
+			results_page=int(results_page[0])
+			params_dict=urlunencode(params)
+			params_dict['results_per_page']=results_per_page
+			if results_page==1:
+				prev_uri=None
+				next_dict=params_dict
+				next_dict['results_page']=2
+				next_uri='?'.join([r.build_absolute_uri('?'),urllib.parse.urlencode(next_dict)])
+			else:
+				next_dict=dict(params_dict)
+				prev_dict=dict(params_dict)
+				prev_dict['results_page']=results_page-1
+				next_dict['results_page']=results_page+1
+				next_uri='?'.join([r.build_absolute_uri('?'),urllib.parse.urlencode(next_dict)])
+				prev_uri='?'.join([r.build_absolute_uri('?'),urllib.parse.urlencode(prev_dict)])
+		if (results_page)*results_per_page>results_count:
+			next_uri=None
+		start_idx=(results_page-1)*results_per_page
+		end_idx=(results_page)*results_per_page
+		queryset=queryset[start_idx:end_idx]
+	else:
+		next_uri=None
+		prev_uri=None
+	
+	return queryset,selected_fields,next_uri,prev_uri,results_count
+
 
 def get_req(queryset,s,r,options_dict,auto_prefetch=True,retrieve_all=False):
 	

--- a/src/voyage/views.py
+++ b/src/voyage/views.py
@@ -75,6 +75,45 @@ class VoyageList(generics.GenericAPIView):
 			outputs=serialized
 		t=timer('flattening',t,done=True)
 		return JsonResponse(outputs,safe=False,headers=headers)
+	def post(self,request):
+		print("username:",request.auth.user)
+		t=timer('FETCHING...',[])
+		queryset=Voyage.objects.all()
+		queryset,selected_fields,next_uri,prev_uri,results_count=post_req(queryset,self,request,voyage_options)
+		headers={"next_uri":next_uri,"prev_uri":prev_uri,"total_results_count":results_count}
+		#read_serializer=VoyageSerializer(queryset,many=True,selected_fields=selected_fields)
+		t=timer('building query',t)
+		read_serializer=VoyageSerializer(queryset,many=True)
+		t=timer('sql execution',t)
+		serialized=read_serializer.data
+		t=timer('serializing',t)
+
+		#if the user hasn't selected any fields (default), then get the fully-qualified var names as the full list
+		if selected_fields==[]:
+			selected_fields=list(voyage_options.keys())
+		outputs=[]
+		
+		hierarchical=request.POST.get('hierarchical')
+		if str(hierarchical).lower() in ['false','0','f','n']:
+			hierarchical=False
+		else:
+			hierarchical=True
+		
+		if hierarchical==False:
+			for s in serialized:
+				d={}
+				for selected_field in selected_fields:
+					#In this flattened view, the reverse relationship breaks the references to the outcome variables in the serializer
+					#not badly -- you just get some repeat, nested data -- but that's unhelpful
+					#The fix will be to make it a through table relationship
+					keychain=selected_field.split('__')
+					bottomval=bottomout(s,list(keychain))
+					d[selected_field]=bottomval
+				outputs.append(d)
+		else:
+			outputs=serialized
+		t=timer('flattening',t,done=True)
+		return JsonResponse(outputs,safe=False,headers=headers)
 
 #VOYAGES SCATTER DATAFRAME ENDPOINT (experimental and going to be a resource hog!)
 class VoyageAggregations(generics.GenericAPIView):
@@ -98,14 +137,56 @@ class VoyageAggregations(generics.GenericAPIView):
 				else:
 					output_dict[varname]={fn:a[k]}
 		return JsonResponse(output_dict,safe=False)
+	def post(self,request):
+		#print("username:",request.auth.user)
+		params=request.GET
+		aggregations=params.get('aggregate_fields')
+		queryset=Voyage.objects.all()
+		aggregation,selected_fields,next_uri,prev_uri,results_count=post_req(queryset,self,request,voyage_options,retrieve_all=True)
+		output_dict={}
+		for a in aggregation:
+			for k in a:
+				v=a[k]
+				fn=k.split('__')[-1]
+				varname=k[:-len(fn)-2]
+				if varname in output_dict:
+					output_dict[varname][fn]=a[k]
+				else:
+					output_dict[varname]={fn:a[k]}
+		return JsonResponse(output_dict,safe=False)
 
 #VOYAGES SCATTER DATAFRAME ENDPOINT (experimental and going to be a resource hog!)
 class VoyageDataFrames(generics.GenericAPIView):
 	serializer_class=VoyageSerializer
 	authentication_classes=[TokenAuthentication]
 	permission_classes=[IsAuthenticated]
+	def post(self,request):
+		t=timer("FETCHING...",[])
+		params=request.GET
+		retrieve_all=True
+		if 'results_per_page' in params:
+			retrieve_all=False
+		queryset=Voyage.objects.all()
+		queryset,selected_fields,next_uri,prev_uri,results_count=post_req(queryset,self,request,voyage_options,auto_prefetch=False,retrieve_all=retrieve_all)
+		headers={"next_uri":next_uri,"prev_uri":prev_uri,"total_results_count":results_count}
+		sf=list(selected_fields)
+		t=timer('building query',t)
+		serialized=VoyageSerializer(queryset,many=True,selected_fields=selected_fields)
+		t=timer('sql execution',t)
+		serialized=serialized.data
+		t=timer('serialization',t)
+		output_dicts={}
+		for selected_field in sf:
+			keychain=selected_field.split('__')
+			for s in serialized:
+				bottomval=bottomout(s,list(keychain))
+				if selected_field in output_dicts:
+					output_dicts[selected_field].append(bottomval)
+				else:
+					output_dicts[selected_field]=[bottomval]
+		t=timer('flattening',t,done=True)
+		return JsonResponse(output_dicts,safe=False,headers=headers)
 	def get(self,request):
-		#print("username:",request.auth.user)
 		t=timer("FETCHING...",[])
 		params=request.GET
 		retrieve_all=True
@@ -142,6 +223,75 @@ class VoyagePlaceList(generics.GenericAPIView):
 	def options(self,request):
 		schema=options_handler(self,request,geo_options)
 		return JsonResponse(schema,safe=False)
+	def post(self,request):
+		#print("username:",request.auth.user)
+		t=timer("FETCHING...",[])
+		queryset=Place.objects.all()
+		queryset,selected_fields,next_uri,prev_uri,results_count=post_req(queryset,self,request,geo_options,retrieve_all=True)
+		t=timer('building query',t)
+		read_serializer=PlaceSerializer(queryset,many=True)
+		t=timer('sql execution',t)
+		serialized=read_serializer.data
+		t=timer('serialization',t)
+		params=request.GET
+		tree={}
+		
+		hierarchical=request.POST.get('hierarchical')
+		if str(hierarchical).lower() in ['false','0','f','n']:
+			hierarchical=False
+		else:
+			hierarchical=True
+		
+		if hierarchical:
+			for place in serialized:
+				broadregion_id=place['region']['broad_region']['id']
+				region_id=place['region']['id']
+				place_id=place['id']
+				minimal_place_dict=dict(place)
+				del(minimal_place_dict['region'])
+				minimal_region_dict=dict(place['region'])
+				del(minimal_region_dict['broad_region'])
+				if broadregion_id not in tree:
+					tree[broadregion_id]=place['region']['broad_region']
+					tree[broadregion_id]['regions']={region_id:minimal_region_dict}
+					tree[broadregion_id]['regions'][region_id]['places']={place_id:minimal_place_dict}
+				else:
+					if region_id not in tree[broadregion_id]['regions']:
+						tree[broadregion_id]['regions'][region_id]=minimal_region_dict
+						tree[broadregion_id]['regions'][region_id]['places']={place_id:minimal_place_dict}
+					else:
+						tree[broadregion_id]['regions'][region_id]['places'][place_id]=minimal_place_dict
+			tree_list=[]
+			for broadregion_id in tree:
+				item=dict(tree[broadregion_id])
+				item['regions']=[]
+				for region_id in tree[broadregion_id]['regions']:
+					region=dict(tree[broadregion_id]['regions'][region_id])
+					places=[]
+					for place_id in region['places']:
+						places.append(region['places'][place_id])
+					region['places']=places
+					item['regions'].append(region)
+				tree_list.append(item)						
+			outputs=tree_list
+		else:
+			#if the user hasn't selected any fields (default), then get the fully-qualified var names as the full list
+			if selected_fields==[]:
+				selected_fields=list(geo_options.keys())
+			outputs=[]
+			for s in serialized:
+				d={}
+				for selected_field in selected_fields:
+					#In this flattened view, the reverse relationship breaks the references to the outcome variables in the serializer
+					#not badly -- you just get some repeat, nested data -- but that's unhelpful
+					#The fix will be to make it a through table relationship
+					keychain=selected_field.split('__')
+					bottomval=bottomout(s,list(keychain))
+					d[selected_field]=bottomval
+				outputs.append(d)
+			
+		t=timer('flattening',t,True)
+		return JsonResponse(outputs,safe=False)
 	def get(self,request):
 		#print("username:",request.auth.user)
 		t=timer("FETCHING...",[])
@@ -218,6 +368,42 @@ class VoyageTextFieldAutoComplete(generics.GenericAPIView):
 	serializer_class=VoyageSerializer
 	authentication_classes=[TokenAuthentication]
 	permission_classes=[IsAuthenticated]
+	def post(self,request):
+		#print("username:",request.auth.user)
+		st=time.time()
+		params=request.POST
+		k=next(iter(params))
+		v=params[k]
+		retrieve_all=True
+		queryset=Voyage.objects.all()		
+		kwargs={'{0}__{1}'.format(k, 'icontains'):v}
+		queryset=queryset.filter(**kwargs)
+		queryset=queryset.prefetch_related(k)
+		queryset=queryset.order_by(k)
+		results_count=queryset.count()
+		fetchcount=10
+		vals=[]
+		for v in queryset.values_list(k).iterator():
+			if v not in vals:
+				vals.append(v)
+			if len(vals)>=fetchcount:
+				break
+		def flattenthis(l):
+			fl=[]
+			for i in l:
+				if type(i)==tuple:
+					for e in i:
+						fl.append(e)
+				else:
+					fl.append(i)
+			return fl
+		val_list=flattenthis(l=vals)
+		output_dict={
+			k:val_list,
+			"results_count":results_count
+		}
+		print("executed in",time.time()-st,"seconds")
+		return JsonResponse(output_dict,safe=False)
 	def get(self,request):
 		#print("username:",request.auth.user)
 		st=time.time()
@@ -229,6 +415,7 @@ class VoyageTextFieldAutoComplete(generics.GenericAPIView):
 		kwargs={'{0}__{1}'.format(k, 'icontains'):v}
 		queryset=queryset.filter(**kwargs)
 		queryset=queryset.prefetch_related(k)
+		queryset=queryset.order_by(k)
 		results_count=queryset.count()
 		fetchcount=10
 		vals=[]

--- a/tablerequirements.md
+++ b/tablerequirements.md
@@ -1,0 +1,105 @@
+Requirements for a flexible table:
+
+TOP-LINE
+
+* We're working to replicate the functionality in the "Results" tab here: https://www.slavevoyages.org/voyage/database
+* This should be designed so that it works for both of the following endpoints:
+	* Voyages: https://voyages3-api.crc.rice.edu/voyage/
+	* People https://voyages3-api.crc.rice.edu/past/
+* Design features in the API that should make this possible
+	* Each column corresponds to a single variable in the db
+	* Variable labels and data types are accessible through an OPTIONS call
+* Admin view
+	* Necessary: elect which variables are available to the user in the table view
+	* Reach goal: organize how these vars are grouped in the search menu
+* Results tabular view
+	* User can select which columns to display in the table
+	* With a default list already being in place
+	* And user can search/filter on and sort by any variable that the admin view has enabled
+	* Clicking on a row opens a modal card view that shows all vars
+* Card view
+	* Easy toggle from table to card view
+	* No filter menus on card view
+	* Click to expand a card to show all vars on an item
+* Lazy loading/virtual scrolling on both tabular & card views (reach goal)
+
+OPEN QUESTIONS
+
+* How do we organize the table, the filters, and the available variables?
+	* I'm thinking something like this: https://react-table.tanstack.com/docs/examples/filtering
+		* Folds the search/filter option components into the header row
+		* Vars are grouped
+		* We could, hopefully
+			* Allow the group header to be the place where a user elects to show or hide columns
+	* Very much open to alternatives -- but right now we're not maximizing our real estate.
+* Where do we display the active searches/filters, and make it easy to modify or remove those filters?
+* When a user modifies a filter, do we automatically execute the search? Or do they have to hit a submit button? I'd personally like to try the automatic execution.
+* How do we display highly nested data?
+	* Perhaps a nested table for cases like voyages embedded in PAST (see https://voyages3-api.crc.rice.edu/past/)
+	* But probably something like a text formatter for cases like voyage_sourceconnection (see https://voyages3-api.crc.rice.edu/voyage/)
+
+DETAILED BREAKDOWN
+
+* The labels for the columns must come from an options call
+	* (this allows the Voyages team to change the labels on the API side)
+* The user must be able to select which columns are shown in the table
+	* But the react app will need an administrative interface that determines which columns are available for user selection
+		* (We have nearly 1000 fields, so we're going to need to pare it down)
+	* The means of governing this would be, ideally, a json file that looks like this: https://github.com/JohnMulligan/voyages-api/blob/main/src/voyage/voyage_options.json
+		* But which has one extra attribute for each field, something like "visible" w boolean values
+		* I would suggest a simple tree structure w checkboxes
+			* Looks like OPTIONS https://voyages3-api.crc.rice.edu/voyage/?hierarchical=False
+			* Xinna Pan has a working example of this tree structure: https://github.com/XinnaPan/Slave_Voyage
+		* Indeed, by managing this with a flat json file that has the same structure as our OPTIONS response
+			* You'd be able to quickly identify whether a variable had become unavailable, or its datatype or label had changed
+			* In fact, this admin tool would eventually replace my manual management of these OPTIONS json files
+	* We will want a similar (if not combined?) interface for organizing the grouping of vars in table and card displays
+		* This could probably be reduced to a json flat file
+		* That hierarchically nests just the names of the visible variables
+* Sorting is easy: https://voyages3-api.crc.rice.edu/voyage/?order_by=VARNAME1,-VARNAME2....
+* Searching/filtering is relatively straightforward for now
+	* Quick breakdown of field types:
+		* As of right now, there are only 4 types of field we're concerned with allowing users to filter on:
+			* <class 'rest_framework.fields.DecimalField'>
+			* <class 'rest_framework.fields.FloatField'>
+			* <class 'rest_framework.fields.IntegerField'>
+			* <class 'rest_framework.fields.CharField'>
+		* "table" type field is a special case:
+			* essentially a placeholder that allows for hierarchical nesting of fields
+			* can't be searched on
+		* the below types can be ignored for now
+			* <class 'rest_framework.fields.BooleanField'> (though this has been implemented)
+			* <class 'rest_framework.fields.DateTimeField'>
+			* <class 'rest_framework.relations.PrimaryKeyRelatedField'>
+	* Numeric fields accept ranges and give back inclusive matches on that range: varname=min,max
+		* e.g., https://voyages3-api.crc.rice.edu/voyage/?voyage_dates__imp_arrival_at_port_of_dis_yyyy=1800,1850
+		* The filter component should therefore be a range slider -- and I think they'll all work well with a step of 1
+		* The min/max for the range slider, when a user calls it up, can be obtained by hitting the stats endpoint: https://voyages3-api.crc.rice.edu/voyage/aggregations?aggregate_fields=VARNAME
+	* Text fields accept strings and give back inexact matches: varname=str
+		* e.g., https://voyages3-api.crc.rice.edu/voyage/?voyage_itinerary__imp_principal_region_slave_dis__region=Barbados
+		* but we're going to tweak this a bit -- see below
+* Improving text field searching/filtering
+	* You'll probably want to start with a simple text input just to get it working
+	* But very quickly iterate that into an autocomplete selector
+	* Autocomplete selection workflow
+		* A user selects a text field they want to filter on
+		* A text input is presented which, as they type,
+			* hits the autocomplete endpoint: https://voyages3-api.crc.rice.edu/voyage/autocomplete?VARNAME=PARTIALSTRING
+			* provides a drop-down menu of the results and lets them select up to 10
+* Menu special cases
+	* Geo var selection/filtering
+		* Almost certainly has to be displayed in a nested format, just as it currently is
+		* And ideally, we'd be able to do the same sort of tree autocomplete filtering that's currently enabled
+		* Fortunately, we have an endpoint for that! https://voyages3-api.crc.rice.edu/voyage/geo
+* Pagination
+	* req params:
+		* results_per_page=INT (default = 10, make the max = 100 for now)
+		* results_page=INT
+	* resp headers that will help w pagination:
+		* next_uri=URI or None
+		* prev_uri=URI or None
+		* total_results_count=INT
+* Exclude the following functionality from this first build
+	* Download results
+	* Saved searches
+	


### PR DESCRIPTION
This changes text filtering into exact matches only, in order to enable the autocomplete flow I've got in mind.

Also, it still implicitly relies on the GET method insofar as the pagination headers (next_uri,prev_uri) are still generated. Will have to deprecate this once I know how users want that info. to come back to them on a POST req.

Remains to be seen if we end up simply deprecating GET.