### PR TITLE
basic autocomplete error handling + drf options preflight fix cleanup

### DIFF
--- a/src/permissions.py
+++ b/src/permissions.py
@@ -1,8 +1,0 @@
-from rest_framework.permissions import IsAuthenticated
-
-class AllowOptionsAuthentication(IsAuthenticated):
-    def has_permission(self, request, view):
-        if request.method == 'OPTIONS':
-            return True
-        return request.user and request.user.is_authenticated
-


### PR DESCRIPTION
Documentation on why the options preflight issue was cropping up:

- CORS kicks off with a "preflight" OPTIONS call to the endpoint, supposedly to ensure that the main POST request that follows will be accepted
- Django Rest Framework doesn't allow for granular control over different auth for different methods (e.g. POST vs. OPTIONS)
- Instead, you have to use a third-party plugin to allow these CORS preflight requests

... which does not inspire confidence in DRF. this should just be a flag in a settings file, not a plugin.

https://github.com/encode/django-rest-framework/issues/5616