### PR TITLE
removed dynamic serialization from all list-style api views except fo…

### DIFF
--- a/src/geo/serializers.py
+++ b/src/geo/serializers.py
@@ -1,29 +1,65 @@
 from rest_framework import serializers
 from rest_framework.fields import SerializerMethodField,IntegerField,CharField
 import re
+import pprint
 from .models import *
 
-class LocationTypeSerializer(serializers.ModelSerializer):
+class DynamicFieldsModelSerializer(serializers.ModelSerializer):
+	def __init__(self, *args, **kwargs):
+		dynamicfieldsserializermode=kwargs.pop('dynamicfieldsserializermode',None)
+		selected_fields = kwargs.pop('selected_fields', None)
+	
+		super().__init__(*args, **kwargs)
+		pp = pprint.PrettyPrinter(indent=4)
+		if selected_fields is not None and dynamicfieldsserializermode:
+			def nestthis(keychain,thisdict={}):
+				while keychain:
+					k=keychain.pop(0)
+					kvs=k.split('__')
+					if len(kvs)==2:
+						i,v=kvs
+						if i in thisdict:
+							thisdict[i][v]={}
+						else:
+							thisdict[i]={v:{}}
+				
+					elif len(kvs)==1:
+						thisdict[kvs[0]]={}
+					else:
+						i=kvs[0]
+						j=['__'.join(kvs[1:])]
+						if i in thisdict:
+							thisdict[i]=nestthis(j,thisdict[i])
+						else:
+							thisdict[i]=nestthis(j,{})
+				return thisdict
+		
+			selected_fields_dict=nestthis(selected_fields)
+			print("--selected fields--")
+			pp.pprint(selected_fields_dict)
+			self=nest_selected_fields(self,selected_fields_dict)
+			
+class LocationTypeSerializer(DynamicFieldsModelSerializer):
 	class Meta:
 		model=LocationType
 		fields='__all__'
 
-class PolygonSerializer(serializers.ModelSerializer):
+class PolygonSerializer(DynamicFieldsModelSerializer):
 	class Meta:
 		model=Polygon
 		fields='__all__'
 
-class LocationParentSerializer(serializers.ModelSerializer):
+class LocationParentSerializer(DynamicFieldsModelSerializer):
 	class Meta:
 		model=Location
 		fields='__all__'
 
-class LocationChildSerializer(serializers.ModelSerializer):
+class LocationChildSerializer(DynamicFieldsModelSerializer):
 	class Meta:
 		model=Location
 		fields='__all__'
 
-class LocationSerializerDeep(serializers.ModelSerializer):
+class LocationSerializerDeep(DynamicFieldsModelSerializer):
 	child_of=LocationParentSerializer(many=False)
 	parent_of=LocationChildSerializer(many=True)
 	spatial_extent=PolygonSerializer(many=False)
@@ -34,14 +70,14 @@ class LocationSerializerDeep(serializers.ModelSerializer):
 
 ##REMOVING CHILD_OF AND PARENT_OF RECORDS FROM THE MAIN LOCATION SERIALIZER
 ##IT HUGELY REDUCES THE OVERHEAD HERE
-class LocationSerializer(serializers.ModelSerializer):
+class LocationSerializer(DynamicFieldsModelSerializer):
 	spatial_extent=PolygonSerializer(many=False)
 	location_type=LocationTypeSerializer(many=False)
 	class Meta:
 		model=Location
 		fields='__all__'
 
-class AdjacencySerializer(serializers.ModelSerializer):
+class AdjacencySerializer(DynamicFieldsModelSerializer):
 	source=LocationSerializer(many=False)
 	target=LocationSerializer(many=False)
 	class Meta:

--- a/src/geo/views.py
+++ b/src/geo/views.py
@@ -61,8 +61,6 @@ class LocationList(generics.GenericAPIView):
 					hierarchical=True
 		
 				if hierarchical==False:
-					if selected_fields==[]:
-						selected_fields=[i for i in location_options]
 			
 					for s in serialized:
 						d={}

--- a/src/past/enslaved_options.json
+++ b/src/past/enslaved_options.json
@@ -5714,6 +5714,36 @@
     "label": "Transaction",
     "flatlabel": "enslaved in relation : enslavement relation : enslaver in relation : Transaction"
   },
+  "transactions__transaction__enslaved_person": {
+    "type": "table",
+    "label": "enslaved in relation",
+    "flatlabel": "enslaved in relation : enslavement relation : enslaved in relation"
+  },
+  "transactions__transaction__enslaved_person__id": {
+    "type": "<class 'rest_framework.fields.IntegerField'>",
+    "label": "Id",
+    "flatlabel": "enslaved in relation : enslavement relation : enslaved in relation : Id"
+  },
+  "transactions__transaction__enslaved_person__enslaved": {
+    "type": "table",
+    "label": "enslaved",
+    "flatlabel": "enslaved in relation : enslavement relation : enslaved in relation : enslaved"
+  },
+  "transactions__transaction__enslaved_person__enslaved__documented_name": {
+    "type": "<class 'rest_framework.fields.CharField'>",
+    "label": "Documented name",
+    "flatlabel": "enslaved in relation : enslavement relation : enslaved in relation : enslaved : Documented name"
+  },
+  "transactions__transaction__enslaved_person__enslaved__id": {
+    "type": "<class 'rest_framework.fields.IntegerField'>",
+    "label": "Id",
+    "flatlabel": "enslaved in relation : enslavement relation : enslaved in relation : enslaved : Id"
+  },
+  "transactions__transaction__enslaved_person__transaction": {
+    "type": "<class 'rest_framework.relations.PrimaryKeyRelatedField'>",
+    "label": "Transaction",
+    "flatlabel": "enslaved in relation : enslavement relation : enslaved in relation : Transaction"
+  },
   "transactions__transaction__source": {
     "type": "table",
     "label": "source",

--- a/src/past/serializers.py
+++ b/src/past/serializers.py
@@ -3,13 +3,16 @@ from rest_framework.fields import SerializerMethodField,IntegerField,CharField
 import re
 from .models import *
 from voyage.serializers import *
+import pprint
 
 class DynamicFieldsModelSerializer(serializers.ModelSerializer):
 	def __init__(self, *args, **kwargs):
+		dynamicfieldsserializermode=kwargs.pop('dynamicfieldsserializermode',None)
 		selected_fields = kwargs.pop('selected_fields', None)
+	
 		super().__init__(*args, **kwargs)
 		pp = pprint.PrettyPrinter(indent=4)
-		if selected_fields is not None:
+		if selected_fields is not None and dynamicfieldsserializermode:
 			def nestthis(keychain,thisdict={}):
 				while keychain:
 					k=keychain.pop(0)
@@ -20,7 +23,7 @@ class DynamicFieldsModelSerializer(serializers.ModelSerializer):
 							thisdict[i][v]={}
 						else:
 							thisdict[i]={v:{}}
-					
+				
 					elif len(kvs)==1:
 						thisdict[kvs[0]]={}
 					else:
@@ -31,12 +34,12 @@ class DynamicFieldsModelSerializer(serializers.ModelSerializer):
 						else:
 							thisdict[i]=nestthis(j,{})
 				return thisdict
-			
+		
 			selected_fields_dict=nestthis(selected_fields)
 			print("--selected fields--")
 			pp.pprint(selected_fields_dict)
 			self=nest_selected_fields(self,selected_fields_dict)
-
+			
 class CaptiveFateSerializer(DynamicFieldsModelSerializer):
 	class Meta:
 		model=CaptiveFate

--- a/src/past/views.py
+++ b/src/past/views.py
@@ -80,8 +80,6 @@ class EnslavedList(generics.GenericAPIView):
 					hierarchical=True
 		
 				if hierarchical==False:
-					if selected_fields==[]:
-						selected_fields=[i for i in enslaved_options]
 			
 					for s in serialized:
 						d={}
@@ -241,8 +239,6 @@ class EnslaverList(generics.GenericAPIView):
 					hierarchical=True
 	
 				if hierarchical==False:
-					if selected_fields==[]:
-						selected_fields=[i for i in enslaver_options]
 		
 					for s in serialized:
 						d={}
@@ -318,10 +314,6 @@ class EnslavedDataFrames(generics.GenericAPIView):
 			queryset,selected_fields,next_uri,prev_uri,results_count,error_messages=post_req(queryset,self,request,enslaved_options,auto_prefetch=False,retrieve_all=retrieve_all,selected_fields_exception=True)
 			if len(error_messages)==0:
 				headers={"next_uri":next_uri,"prev_uri":prev_uri,"total_results_count":results_count}
-				if selected_fields==[]:
-					sf=list(enslaved_options.keys())
-				else:
-					sf=[i for i in selected_fields if i in list(enslaved_options.keys())]
 			
 				serialized=EnslavedSerializer(queryset,many=True,selected_fields=selected_fields)
 			

--- a/src/voyage/serializers.py
+++ b/src/voyage/serializers.py
@@ -10,10 +10,12 @@ from docs.serializers import *
 
 class DynamicFieldsModelSerializer(serializers.ModelSerializer):
 	def __init__(self, *args, **kwargs):
+		dynamicfieldsserializermode=kwargs.pop('dynamicfieldsserializermode',None)
 		selected_fields = kwargs.pop('selected_fields', None)
+	
 		super().__init__(*args, **kwargs)
 		pp = pprint.PrettyPrinter(indent=4)
-		if selected_fields is not None:
+		if selected_fields is not None and dynamicfieldsserializermode:
 			def nestthis(keychain,thisdict={}):
 				while keychain:
 					k=keychain.pop(0)
@@ -24,7 +26,7 @@ class DynamicFieldsModelSerializer(serializers.ModelSerializer):
 							thisdict[i][v]={}
 						else:
 							thisdict[i]={v:{}}
-					
+				
 					elif len(kvs)==1:
 						thisdict[kvs[0]]={}
 					else:
@@ -35,7 +37,7 @@ class DynamicFieldsModelSerializer(serializers.ModelSerializer):
 						else:
 							thisdict[i]=nestthis(j,{})
 				return thisdict
-			
+		
 			selected_fields_dict=nestthis(selected_fields)
 			print("--selected fields--")
 			pp.pprint(selected_fields_dict)


### PR DESCRIPTION
…r voyage/dataframes. dataframes need this functionality to build the flask index; but it makes selected_field functionality unreliable in high traffic. has to be reserved for internal use, at least for now.

--> as a consequence, though, we should be able to reliably use the select_fields parameter on the list views -- previously it was glitching out at above approximately 20 selected fields, but that should not be the case anymore, as the pruning of fields now happens post-serialization (but, again, not in dataframes).