### PR TITLE
Feb2patches

### DIFF
--- a/api/assessment/views.py
+++ b/api/assessment/views.py
@@ -27,10 +27,10 @@ from voyages3.localsettings import STATS_BASE_URL
 
 #LONG-FORM TABULAR ENDPOINT. PAGINATION IS A NECESSITY HERE!
 ##HAVE NOT YET BUILT IN ORDER-BY FUNCTIONALITY
-# @extend_schema(
-#         exclude=True
-#     )
-# #right now, this thing dumps all 7 MB out -- so we can't show it on swagger
+@extend_schema(
+        exclude=True
+    )
+#right now, this thing dumps all 7 MB out -- so we can't show it on swagger
 class AssessmentList(generics.GenericAPIView):
 	serializer_class=EstimateSerializer
 	authentication_classes=[TokenAuthentication]
@@ -43,13 +43,12 @@ class AssessmentList(generics.GenericAPIView):
 		times.append(time.time())
 		queryset=Estimate.objects.all()
 		estimate_options=getJSONschema('Estimate',hierarchical=False)
-		queryset,selected_fields,results_count,error_messages=post_req(
+		queryset,results_count=post_req(
 			queryset,
 			self,
 			request,
-			estimate_options,
-			auto_prefetch=True,
-			retrieve_all=True
+			Estimate_options,
+			auto_prefetch=True
 		)
 		read_serializer=EstimateSerializer(queryset,many=True,read_only=True)
 		serialized=read_serializer.data

--- a/api/document/admin.py
+++ b/api/document/admin.py
@@ -1,12 +1,24 @@
 from django.contrib import admin
 from document.models import *
 from past.models import *
+import nested_admin
 from voyage.models import *
 
-class PageAdmin(admin.ModelAdmin):
+
+class TranscriptionInline(nested_admin.NestedStackedInline):
+	model=Transcription
+	max_num=1
+	classes = ['collapse']
+	verbose_name_plural="Transcriptions"
+	can_delete=False
+
+class PageAdmin(nested_admin.NestedModelAdmin):
 	readonly_fields=['page_url','image_filename','iiif_baseimage_url']
 	search_fields=['page_url','image_filename']
 	list_display=['page_url','image_filename']
+	inlines=[
+		TranscriptionInline,
+	]
 	model=Page
 
 class ShortRefAdmin(admin.ModelAdmin):

--- a/api/document/management/commands/iiif_generate_manifests.py
+++ b/api/document/management/commands/iiif_generate_manifests.py
@@ -253,11 +253,16 @@ class Command(BaseCommand):
 						enslaved_links['value']['en'].append(link)
 					metadata.append(enslaved_links)
 				
+				if type(source.title)!=list:
+					published_title=[source.title]
+				else:
+					published_title=source.title
+				
 				manifest = {
 					"@context": "http://iiif.io/api/presentation/3/context.json",
 					"id": base_id,
 					"type": "Manifest",
-					"label": { 'en': source.title },
+					"label": { 'en': published_title },
 					"metadata": metadata,
 					"viewingDirection": "left-to-right",
 					"behavior": ["paged"],

--- a/api/document/management/commands/iiif_generate_manifests.py
+++ b/api/document/management/commands/iiif_generate_manifests.py
@@ -14,6 +14,7 @@ from django.db.models import Prefetch
 from document.models import Source
 from voyages3.settings import STATIC_ROOT
 from voyages3.localsettings import VOYAGES_FRONTEND_BASE_URL,OPEN_API_BASE_API,STATIC_URL
+import os
 
 # We special case these sources as they have issues with their IIIF Image
 # Service preventing us from creating manifests that point directly to the image
@@ -60,6 +61,7 @@ class Command(BaseCommand):
 		return [m.group(i) for i in [2, 3]]
 
 	def handle(self, *args, **options):
+		
 		manifest_sources=Source.objects.all().filter(~Q(page_connections__page=None))
 		
 		#screen out sources that lack either pages  
@@ -266,6 +268,11 @@ class Command(BaseCommand):
 				
 				filename = f"{source.zotero_group_id}__{source.zotero_item_id}.json"
 				out_dir: pathlib.Path = options['out_dir']
+				
+				if not os.path.exists(out_dir):
+					os.makedirs(out_dir)
+				
+				
 				with open(out_dir.joinpath(filename), 'w', encoding='utf-8') as f:
 					json.dump(manifest, f)
 				source.thumbnail = first_thumb[0]['id']

--- a/api/document/models.py
+++ b/api/document/models.py
@@ -3,7 +3,7 @@ import re
 from voyage.models import Voyage
 from past.models import Enslaved,EnslaverIdentity,EnslavementRelation
 from common.models import NamedModelAbstractBase,SparseDateAbstractBase
-from voyages3.localsettings import STATIC_URL
+from voyages3.localsettings import STATIC_URL,OPEN_API_BASE_API
 
 class DocSparseDate(SparseDateAbstractBase):
 	pass
@@ -342,6 +342,6 @@ class Source(models.Model):
 	@property
 	def iiif_manifest_url(self):
 		if self.has_published_manifest and self.zotero_group_id and self.zotero_item_id is not None:
-			return(f'{STATIC_URL}iiif_manifests/{self.zotero_group_id}__{self.zotero_item_id}.json')
+			return(f'{OPEN_API_BASE_API}{STATIC_URL}iiif_manifests/{self.zotero_group_id}__{self.zotero_item_id}.json')
 		else:
 			return None

--- a/api/document/models.py
+++ b/api/document/models.py
@@ -9,28 +9,30 @@ class DocSparseDate(SparseDateAbstractBase):
 	pass
 
 class Transcription(models.Model):
-    """
-    The text transcription of a page in a document.
-    ADAPTED FROM DELLAMONICA'S MODEL
-    """
-    page = models.ForeignKey(
-    	'Page',
-    	null=False,
-        on_delete=models.CASCADE,
-        related_name='transcriptions'
-    )
-    #page number will come from the sourcepageconnection.order field
+	"""
+	The text transcription of a page in a document.
+	ADAPTED FROM DELLAMONICA'S MODEL
+	"""
+	page = models.ForeignKey(
+		'Page',
+		null=False,
+		on_delete=models.CASCADE,
+		related_name='transcriptions'
+	)
+	#page number will come from the sourcepageconnection.order field
 	#page_number = models.IntegerField(null=False)
-    # A BCP47 language code for the transcription text.
-    # https://www.rfc-editor.org/bcp/bcp47.txt
-    language_code = models.CharField(max_length=20, null=False)
-    text = models.TextField(null=False)
-    # Indicates whether the transcription is in the original language or a
-    # translation.
-    is_translation = models.BooleanField(null=False)
+	# A BCP47 language code for the transcription text.
+	# https://www.rfc-editor.org/bcp/bcp47.txt
+	language_code = models.CharField(max_length=20, null=False)
+	text = models.TextField(null=False)
+	# Indicates whether the transcription is in the original language or a
+	# translation.
+	is_translation = models.BooleanField(null=False)
 
-    def __str__(self):
-        return f"Transcription of page {self.page}: {self.text}"
+	def __str__(self):
+		if len(self.text)>20:
+			snippet=self.text[:19]+"..."
+		return f"Transcription of page {self.page}: {snippet}"
 
 class Page(models.Model):
 	"""

--- a/api/document/serializers_READONLY.py
+++ b/api/document/serializers_READONLY.py
@@ -4,7 +4,7 @@ import re
 from .models import *
 from drf_spectacular.utils import extend_schema_serializer, OpenApiExample
 from django.core.exceptions import ObjectDoesNotExist
-from voyages3.localsettings import STATIC_URL
+from voyages3.localsettings import STATIC_URL,OPEN_API_BASE_API
 from common.static.Source_options import Source_options
 
 class SourceTypeSerializer(serializers.ModelSerializer):
@@ -113,7 +113,7 @@ class SourceSerializer(serializers.ModelSerializer):
 		fields='__all__'
 	def get_iiif_manifest_url(self,obj):
 		if obj.has_published_manifest and obj.zotero_group_id and obj.zotero_item_id is not None:
-			return(f'{STATIC_URL}iiif_manifests/{obj.zotero_group_id}__{obj.zotero_item_id}.json')
+			return(f'{OPEN_API_BASE_API}{STATIC_URL}iiif_manifests/{obj.zotero_group_id}__{obj.zotero_item_id}.json')
 		else:
 			return None
 

--- a/api/document/templates/single_doc.html
+++ b/api/document/templates/single_doc.html
@@ -26,12 +26,18 @@
 				Link to full image: <br/><a href="{{ spc.page.iiif_baseimage_url }}" target="_blank"><img src="{{ spc.page.square_thumbnail }}"></a></li></ul>
 			{% endif %}
 		</td>
-		{% if spc.page.transcription %}
+		{% if spc.page.transcriptions %}
 		<td>
 				<p><b><a href="/admin/document/page/{{ spc.page.id }}/change/" target="_blank">Edit Transcript Here</a></b></p>
-				<p>
-				 {{ spc.page.transcription }}
-				</p>
+				
+				 {% for transcription in spc.page.transcriptions.all  %}
+				 <p>
+				 	{{ transcription.text }}
+				 
+				 </p>
+				 {% endfor %}
+				 
+				
 				<p></p>
 			
 		</td>

--- a/api/voyages3/settings.py
+++ b/api/voyages3/settings.py
@@ -194,7 +194,7 @@ site = FileBrowserSite(name='filebrowser')
 
 site.storage.location = "static"
 site.directory="uploads/"
-site.storage.base_url = "/static/abcdefg"
+site.storage.base_url = "/abcdefg"
 
 TINYMCE_JS_URL="tinymce/tinymce.min.js"
 TINYMCE_DEFAULT_CONFIG = {


### PR DESCRIPTION
This rolls up a few small bug fixes requested by @ThasaneePuttamadilok @Dellamonica, @derekjkeller and Daniel Domingues

1. The document gallery view has been updated to display the text of the new transcriptions model
2. The page admin view has been updated to show the page transcription(s) as an editable inline
3. The filemanager path in settings.py no longer points static uploads to `static/static/uploads/img.png` but to `static/uploads/img.png` 
4. The iiif manifest generator now recursively creates the static folder it puts the manifests into (if that doesn't exist)
5. The manifest generator now produces valid IIIF v3 manifests (validated this with mirador viewer)

@derekjkeller -- we do need to make one change to localsettings:

`STATIC_URL="https://voyages-api-staging.crc.rice.edu/static/"` has to be `STATIC_URL="static/"`

John