### PR TITLE
Feb 6 patches

### DIFF
--- a/api/assessment/serializers.py
+++ b/api/assessment/serializers.py
@@ -127,7 +127,6 @@ class EstimateDataframesRequestSerializer(serializers.Serializer):
 				],
 				"rows": ["year"],
 				"binsize": 20,
-				"rows_label": "YEAR",
 				"agg_fn": "sum",
 				"vals": ["embarked_slaves","disembarked_slaves"],
 				"mode": "html",

--- a/api/assessment/serializers.py
+++ b/api/assessment/serializers.py
@@ -76,7 +76,31 @@ class EstimateFilterItemSerializer(serializers.Serializer):
 						"searchTerm":[1750,1775]
 					}
 				]
-			}
+			},
+			request_only=True,
+			response_only=False
+		),
+		OpenApiExample(
+			'Multi-level, split value columns',
+			summary='Multi-level, split value columns',
+			description='Here, we request cross-tabs on the geographic locations where enslaved people were embarked, and where they were disembarked. We also request that our columns be grouped in a multi-level way, from broad region to region and place. The cell value we wish to calculate is the number of people embarked and disembarked, and we aggregate these as a sum. We are requesting the first 5 rows of these cross-tab results.',
+			value={
+				"cols": [
+					"embarkation_region__export_area__name",
+					"embarkation_region__name"
+				],
+				"rows": [
+					"disembarkation_region__import_area__name",
+					"disembarkation_region__name"
+				],
+				"binsize": None,
+				"agg_fn": "sum",
+				"vals": ["embarked_slaves"],
+				"mode": "html",
+				"filter": []
+			},
+			request_only=True,
+			response_only=False
 		)
 	]
 )
@@ -88,25 +112,37 @@ class EstimateDataframesRequestSerializer(serializers.Serializer):
 	)
 	filter=EstimateFilterItemSerializer(many=True,allow_null=True,required=False)
 
-############ OFFSET PAGINATION SERIALIZERS
-class EstimateOffsetPaginationSerializer(serializers.Serializer):
-	offset=serializers.IntegerField()
-	limit=serializers.IntegerField()
-	total_results_count=serializers.IntegerField()
-
 ############ CROSSTAB SERIALIZERS
+
+@extend_schema_serializer(
+	examples=[
+		OpenApiExample(
+			'Paginated request for binned years & embarkation geo vars',
+			summary='Multi-level, 20-year bins',
+			description='Here, we request cross-tabs on the geographic locations where enslaved people were embarked in 20-year periods. We also request that our columns be grouped in a multi-level way, from broad region to region and place. The cell value we wish to calculate is the number of people embarked, and we aggregate these as a sum. We are requesting the first 5 rows of these cross-tab results.',
+			value={
+				"cols": [
+					"embarkation_region__export_area__name",
+					"embarkation_region__name"
+				],
+				"rows": ["year"],
+				"binsize": 20,
+				"rows_label": "YEAR",
+				"agg_fn": "sum",
+				"vals": ["embarked_slaves","disembarked_slaves"],
+				"mode": "html",
+				"filter": []
+			}
+		)
+	]
+)
 class EstimateCrossTabRequestSerializer(serializers.Serializer):
-	columns=serializers.ListField(child=serializers.CharField())
-	rows=serializers.CharField()
+	cols=serializers.ListField(child=serializers.CharField())
+	rows=serializers.ListField(child=serializers.CharField())
 	binsize=serializers.IntegerField(allow_null=True,required=False)
-	rows_label=serializers.CharField(allow_null=True)
-	agg_fn=serializers.CharField()
-	value_field=serializers.CharField()
-	offset=serializers.IntegerField()
-	limit=serializers.IntegerField()
-	order_by=serializers.ListField(child=serializers.CharField(allow_null=True),required=False,allow_null=True)
+	vals=serializers.ListField(child=serializers.CharField())
+	mode=serializers.ChoiceField(choices=["html","csv"])
+	filter=EstimateFilterItemSerializer(many=True,allow_null=True,required=False)
 	
 class EstimateCrossTabResponseSerializer(serializers.Serializer):
-	tablestructure=serializers.JSONField()
-	data=serializers.JSONField()
-	metadata=EstimateOffsetPaginationSerializer()
+	data=serializers.CharField()

--- a/api/assessment/views.py
+++ b/api/assessment/views.py
@@ -27,9 +27,9 @@ from voyages3.localsettings import STATS_BASE_URL
 
 #LONG-FORM TABULAR ENDPOINT. PAGINATION IS A NECESSITY HERE!
 ##HAVE NOT YET BUILT IN ORDER-BY FUNCTIONALITY
-@extend_schema(
-        exclude=True
-    )
+# @extend_schema(
+#         exclude=True
+#     )
 #right now, this thing dumps all 7 MB out -- so we can't show it on swagger
 class AssessmentList(generics.GenericAPIView):
 	serializer_class=EstimateSerializer

--- a/api/document/management/commands/iiif_generate_manifests.py
+++ b/api/document/management/commands/iiif_generate_manifests.py
@@ -117,25 +117,22 @@ class Command(BaseCommand):
 					
 					error_count=0
 					max_errors=10
-					standoff=1
+					standoff=10
 					while True:
 						try:
 							req=requests.get(f"{img_url_base}/info.json", timeout=30)
 							req_succeeded=True
 						except:
 							print("Request timeout. Pausing...")
-							error_count+=1
-							if error_count>10:
-								exit()
-							standoff=standoff**2
-							time.sleep(standoff)
 							req_succeeded=False
 							
 						print(req)
-						if req.status_code!=200 and req_succeeded:
-							print(req.status_code,"error fetching",img_url_base)
+						if req.status_code!=200 or not req_succeeded:
+							if req_succeeded:
+								print(req.status_code)
+							print("error fetching",img_url_base)
 							error_count+=1
-							if error_count>10:
+							if error_count>50:
 								exit()
 							standoff=standoff**2
 							time.sleep(standoff)

--- a/api/document/management/commands/iiif_generate_manifests.py
+++ b/api/document/management/commands/iiif_generate_manifests.py
@@ -218,7 +218,7 @@ class Command(BaseCommand):
 				source_voyages=source.source_voyage_connections.all()
 				if source_voyages.count()>0:
 					voyage_links={
-						"label": { 'en': "Linked Voyages" },
+						"label": { 'en': ["Linked Voyages"] },
 						"value": { 'en': [] }
 					}
 					for source_voyage in source_voyages:
@@ -230,7 +230,7 @@ class Command(BaseCommand):
 				source_enslavers=source.source_enslaver_connections.all()
 				if source_enslavers.count()>0:
 					enslaver_links={
-						"label": { 'en': "Linked Enslavers" },
+						"label": { 'en': ["Linked Enslavers"] },
 						"value": { 'en': [] }
 					}
 					for enslaver in source_enslavers:
@@ -243,7 +243,7 @@ class Command(BaseCommand):
 				source_enslaved_people=source.source_enslaved_connections.all()
 				if source_enslaved_people.count()>0:
 					enslaved_links={
-						"label": { 'en': "Linked Enslaved People" },
+						"label": { 'en': ["Linked Enslaved People"] },
 						"value": { 'en': [] }
 					}
 					for source_enslaved_person in source_enslaved_people:

--- a/api/document/management/commands/iiif_generate_manifests.py
+++ b/api/document/management/commands/iiif_generate_manifests.py
@@ -119,14 +119,25 @@ class Command(BaseCommand):
 					max_errors=10
 					standoff=1
 					while True:
-						req=requests.get(f"{img_url_base}/info.json", timeout=30)
+						try:
+							req=requests.get(f"{img_url_base}/info.json", timeout=30)
+							req_succeeded=True
+						except:
+							print("Request timeout. Pausing...")
+							error_count+=1
+							if error_count>10:
+								exit()
+							standoff=standoff**2
+							time.sleep(standoff)
+							req_succeeded=False
+							
 						print(req)
-						if req.status_code!=200:
+						if req.status_code!=200 and req_succeeded:
 							print(req.status_code,"error fetching",img_url_base)
 							error_count+=1
 							if error_count>10:
 								exit()
-							standoff=standoff*4
+							standoff=standoff**2
 							time.sleep(standoff)
 						else:
 							img_info=req.json()

--- a/api/document/models.py
+++ b/api/document/models.py
@@ -218,6 +218,9 @@ class SourceType(models.Model):
 		We'll rely on Zotero's controlled vocabulary from now on.
 	'''
 	name = models.CharField(max_length=255,unique=True)
+	def __str__(self):
+		return self.name
+
 
 class Source(models.Model):
 	"""
@@ -229,13 +232,14 @@ class Source(models.Model):
 	
 	item_url=models.URLField(
 		max_length=400,
-		null=True
+		null=True,
+		blank=True
 	)
 	
 	#from dellamonica's models
-	thumbnail = models.TextField(null=True, help_text='URL for a thumbnail of the Document')
-	bib = models.TextField(null=True, help_text='Formatted bibliography for the Document')
-	manifest_content = models.JSONField(help_text='DCTerms imported from Zotero -- NOT the full manifest',null=True)
+	thumbnail = models.TextField(null=True, help_text='URL for a thumbnail of the Document',blank=True)
+	bib = models.TextField(null=True, help_text='Formatted bibliography for the Document',blank=True)
+	manifest_content = models.JSONField(help_text='DCTerms imported from Zotero -- NOT the full manifest',null=True,blank=True)
 	
 	zotero_group_id=models.IntegerField(
 		"Zotero Integer Group ID",
@@ -260,7 +264,8 @@ class Source(models.Model):
 	
 	zotero_url=models.URLField(
 		max_length=400,
-		null=True
+		null=True,
+		blank=True
 	)
 	
 	source_type=models.ForeignKey(

--- a/stats/app.py
+++ b/stats/app.py
@@ -33,10 +33,10 @@ def load_long_df(endpoint,variables,options):
 	return(df)
 
 registered_caches=[
-# 	voyage_bar_and_donut_charts,
-# 	voyage_summary_statistics,
-# 	voyage_pivot_tables,
-# 	voyage_xyscatter,
+	voyage_bar_and_donut_charts,
+	voyage_summary_statistics,
+	voyage_pivot_tables,
+	voyage_xyscatter,
 	estimate_pivot_tables
 ]
 
@@ -215,7 +215,7 @@ def pivot():
 	
 	pv=pv.fillna(0)
 	html=pv.to_html(index_names=False)
-	html=re.sub('\\nS+','',html)
+	html=re.sub('\\n\s+','',html)
 	return json.dumps(
 		{
 			"data":html
@@ -225,6 +225,7 @@ def pivot():
 
 @app.route('/crosstabs/',methods=['POST'])
 def crosstabs():
+	
 	'''
 	Implements the pandas crosstab function and returns the sparse summary.
 	Excellent for pivot tables and maps (e.g., Origin/Destination pairs for voyages with summary values for those pairs)
@@ -275,10 +276,18 @@ def crosstabs():
 	df=df[df['id'].isin(ids)]
 	
 	yeargroupmode=False
-
-# 	valuetype=options[val]['type']
 	
-	print([df[v] for v in val])
+	def interval_to_str(s):
+		s=str(s)
+		return re.sub('[\s,]+','-',re.sub('[\[\]]','',s))
+
+	def makestr(s):
+		if s is None:
+			return "Unknown"
+		else:
+			return str(s)
+
+	valuetype=options[val]['type']
 	
 	##TBD --> NEED TO VALIDATE THAT THE ROWS VARIABLE IS
 	####1) NUMERIC TO WORK IN THE FIRST PLACE
@@ -313,9 +322,9 @@ def crosstabs():
 		ct.fillna(0)
 	else:
 		ct=pd.crosstab(
-			[df[row] for row in rows],
+			[df[rows]],
 			[df[col] for col in columns],
-			values=val,
+			values=df[val],
 			aggfunc=fn,
 			normalize=normalize,
 			margins=True
@@ -325,19 +334,10 @@ def crosstabs():
 	if order_by is not None:
 		ct=ct.sort_values(by=order_by_list,ascending=ascending)
 	
-	
-	ct=ct.fillna(0)
-	
-	return({"data":json.dumps(ct.to_html())})
-	
-	
 	if len(columns)==1:
 		mlctuples=[[i] for i in list(ct.columns)]
 	else:
 		mlctuples=list(ct.columns)
-	
-	
-	
 	
 # 	print("tuples",mlctuples)
 	
@@ -416,8 +416,7 @@ def crosstabs():
 # 	allcolumns=[re.sub('\.','',"__".join(c)) if c[0]!='All' else 'All' for c in mlctuples]
 	allcolumns=["__".join(c) if c[0]!='All' else 'All' for c in mlctuples]
 	allcolumns.insert(0,indexcol_name)
-	
-	
+	ct=ct.fillna(0)
 	
 # 	print(ct)
 	

--- a/stats/app.py
+++ b/stats/app.py
@@ -164,6 +164,18 @@ def pivot():
 	for val in vals:
 		pv[val]=pv[val].astype('int')
 	
+	#handle a duplicate varname request like
+	#rows=['nation__name'],cols=['nation__name']
+	#which is dumb, because who wants a diagonal matrix???
+	duplicate_indices=[i for i in cols if i in rows]
+	
+	c=1
+	for duplicate_index in duplicate_indices:
+		duplicate_position=cols.index(duplicate_index)
+		pv=eval(f'pv.assign(duplicate_col_{c}=pv[duplicate_index])')
+		cols[duplicate_position]=f'duplicate_col_{c}'
+		c+=1
+	
 	#if we are binning, then rows should only have one varname
 	#and that var should be numeric
 	if binsize is not None:

--- a/stats/app.py
+++ b/stats/app.py
@@ -33,10 +33,10 @@ def load_long_df(endpoint,variables,options):
 	return(df)
 
 registered_caches=[
-	voyage_bar_and_donut_charts,
-	voyage_summary_statistics,
-	voyage_pivot_tables,
-	voyage_xyscatter,
+# 	voyage_bar_and_donut_charts,
+# 	voyage_summary_statistics,
+# 	voyage_pivot_tables,
+# 	voyage_xyscatter,
 	estimate_pivot_tables
 ]
 
@@ -122,9 +122,109 @@ class NotNanDict(dict):
 	def __new__(self, a):
 		return {k: v for k, v in a if not self.is_nan(v) and v!={}} 
 
+
+def interval_to_str(s):
+	s=str(s)
+	return re.sub('[\s,]+','-',re.sub('[\[\]]','',s))
+
+def makestr(s):
+	if s is None:
+		return "Unknown"
+	else:
+		return str(s)
+
+
+@app.route('/pivot/',methods=['POST'])
+def pivot():
+
+	'''
+	We cannot implement multi-level rows in AG Grid
+		1. because it's in the enterprise version
+		2. because it's ugly
+	It is possible that this is the implementation I was looking for all along.
+	'''
+	st=time.time()
+	rdata=request.json
+	dfname=rdata['cachename']
+	ids=rdata['ids']
+	rows=rdata['rows']
+	cols=rdata['cols']
+	vals=rdata['vals']
+	binsize=rdata.get('binsize')
+	mode=rdata['mode']
+	
+	df=eval(dfname)['df']
+	
+	#filter down on the pk's
+	pv=df[df['id'].isin(ids)]
+	
+	pv=pv.fillna(0)
+	
+	#force ints
+	for val in vals:
+		pv[val]=pv[val].astype('int')
+	
+	#if we are binning, then rows should only have one varname
+	#and that var should be numeric
+	if binsize is not None:
+		rows=rows[0]
+		binsize=int(binsize)
+		pv[rows]=pv[rows]
+		pv[rows]=pv[rows].astype('int')
+		binvar_min=pv[rows].min()
+		binvar_max=pv[rows].max()
+		binvar_ints=list(range(int(binvar_min),int(binvar_max)+1))
+		if binvar_max-binvar_min <=binsize:
+			nbins=1
+		else:
+			nbins=int((binvar_max-binvar_min)/binsize)
+		bin_arrays=np.array_split(binvar_ints,nbins)
+		bins=pd.IntervalIndex.from_tuples([(i[0],i[-1]) for i in bin_arrays],closed='both')
+		pv=pv.assign(row_bins=pd.cut(df[rows],bins,include_lowest=True))
+		pv=pv[cols+vals+['row_bins']]
+		pv.rename(columns={"row_bins": rows})
+		pv['row_bins']=pv['row_bins'].astype('str')
+		pv['row_bins']=pv['row_bins'].apply(interval_to_str)
+		rows='row_bins'
+	#pivot
+	
+	
+	if len(vals)==1:
+		vals=vals[0]
+		split_cells=False
+	else:
+		split_cells=True
+	
+	pv=pv.pivot_table(
+		columns=cols,
+		index=rows,
+		values=vals,
+		aggfunc="sum"
+	)
+	
+	#if we're doing split cells
+	#pandas puts the values on top -- flip it to get split cells
+	if split_cells:
+		cl=len(cols)
+		if cl==1:
+			pv=pv.swaplevel(0,len(cols),axis=1).sort_index(axis=1)
+		elif cl==2:
+			#there's got. to be. a better. way.
+			pv=pv.swaplevel(0,1,axis=1).sort_index(axis=1)
+			pv=pv.swaplevel(1,2,axis=1).sort_index(axis=1)
+	
+	pv=pv.fillna(0)
+	html=pv.to_html(index_names=False)
+	html=re.sub('\\nS+','',html)
+	return json.dumps(
+		{
+			"data":html
+		}
+	)
+
+
 @app.route('/crosstabs/',methods=['POST'])
 def crosstabs():
-	
 	'''
 	Implements the pandas crosstab function and returns the sparse summary.
 	Excellent for pivot tables and maps (e.g., Origin/Destination pairs for voyages with summary values for those pairs)
@@ -175,18 +275,10 @@ def crosstabs():
 	df=df[df['id'].isin(ids)]
 	
 	yeargroupmode=False
+
+# 	valuetype=options[val]['type']
 	
-	def interval_to_str(s):
-		s=str(s)
-		return re.sub('[\s,]+','-',re.sub('[\[\]]','',s))
-
-	def makestr(s):
-		if s is None:
-			return "Unknown"
-		else:
-			return str(s)
-
-	valuetype=options[val]['type']
+	print([df[v] for v in val])
 	
 	##TBD --> NEED TO VALIDATE THAT THE ROWS VARIABLE IS
 	####1) NUMERIC TO WORK IN THE FIRST PLACE
@@ -221,9 +313,9 @@ def crosstabs():
 		ct.fillna(0)
 	else:
 		ct=pd.crosstab(
-			[df[rows]],
+			[df[row] for row in rows],
 			[df[col] for col in columns],
-			values=df[val],
+			values=val,
 			aggfunc=fn,
 			normalize=normalize,
 			margins=True
@@ -233,10 +325,19 @@ def crosstabs():
 	if order_by is not None:
 		ct=ct.sort_values(by=order_by_list,ascending=ascending)
 	
+	
+	ct=ct.fillna(0)
+	
+	return({"data":json.dumps(ct.to_html())})
+	
+	
 	if len(columns)==1:
 		mlctuples=[[i] for i in list(ct.columns)]
 	else:
 		mlctuples=list(ct.columns)
+	
+	
+	
 	
 # 	print("tuples",mlctuples)
 	
@@ -315,7 +416,8 @@ def crosstabs():
 # 	allcolumns=[re.sub('\.','',"__".join(c)) if c[0]!='All' else 'All' for c in mlctuples]
 	allcolumns=["__".join(c) if c[0]!='All' else 'All' for c in mlctuples]
 	allcolumns.insert(0,indexcol_name)
-	ct=ct.fillna(0)
+	
+	
 	
 # 	print(ct)
 	


### PR DESCRIPTION

This PR is intended for deployment on staging only.

It addresses the following bugs:

* IIIF manifests were ill-formed when they had linked entities
* The assessments list endpoint needed to be turned on for the voyages-stats engine to pull its data structure
* The administrative interface was not allowing editors to create sources without filling in a few unnecessary fields
* The assessments crosstabs endpoint (which produces the data table) needed to be transformed into an HTML rather than a JSON dump because the table component we have been using, AG Grid, requires an expensive license to turn on row groupings
* Potentially -- if I can get another push up quickly -- add backoff on iiif_generate_manifests script to handle 429 and other errors (I thought I'd done that already, but it seems not, apologies)

Post-deployment tasks, in this order:

* @derekjkeller Clear the redis cache (this should be scripted eventually for all deployments)
* @JohnMulligan Set the has_published_manifest field to False for all OMNO sources (because they have linked entities)
* @JohnMulligan or @derekjkeller Run the iiif_generate_manifests command, with skip-existing=True
* @JohnMulligan or @derekjkeller clear the redis cache once more

Together, steps 2 and 3 will allow for only the problematic manifests to be regenerated.
