### PR TITLE
Replay of PR 207

### DIFF
--- a/api/assessment/views.py
+++ b/api/assessment/views.py
@@ -24,9 +24,10 @@ from voyages3.localsettings import STATS_BASE_URL
 
 
 
-
 #list view. Only keeping it around for the model
-class AssessmentList(generics.RetrieveAPIView):
+class AssessmentList(generics.RetrieveAPIView):	
+	queryset=Estimate.objects.all()
+	lookup_field='id'
 	serializer_class=EstimateSerializer
 	authentication_classes=[TokenAuthentication]
 	permission_classes=[IsAuthenticated]

--- a/stats/app.py
+++ b/stats/app.py
@@ -33,10 +33,10 @@ def load_long_df(endpoint,variables,options):
 	return(df)
 
 registered_caches=[
-	voyage_bar_and_donut_charts,
-	voyage_summary_statistics,
-	voyage_pivot_tables,
-	voyage_xyscatter,
+# 	voyage_bar_and_donut_charts,
+# 	voyage_summary_statistics,
+# 	voyage_pivot_tables,
+# 	voyage_xyscatter,
 	estimate_pivot_tables
 ]
 
@@ -158,76 +158,80 @@ def pivot():
 	#filter down on the pk's
 	pv=df[df['id'].isin(ids)]
 	
-	pv=pv.fillna(0)
-	
-	#force ints
-	for val in vals:
-		pv[val]=pv[val].astype('int')
-	
-	#handle a duplicate varname request like
-	#rows=['nation__name'],cols=['nation__name']
-	#which is dumb, because who wants a diagonal matrix???
-	duplicate_indices=[i for i in cols if i in rows]
-	
-	c=1
-	for duplicate_index in duplicate_indices:
-		duplicate_position=cols.index(duplicate_index)
-		pv=eval(f'pv.assign(duplicate_col_{c}=pv[duplicate_index])')
-		cols[duplicate_position]=f'duplicate_col_{c}'
-		c+=1
-	
-	#if we are binning, then rows should only have one varname
-	#and that var should be numeric
-	if binsize is not None:
-		rows=rows[0]
-		binsize=int(binsize)
-		pv[rows]=pv[rows]
-		pv[rows]=pv[rows].astype('int')
-		binvar_min=pv[rows].min()
-		binvar_max=pv[rows].max()
-		binvar_ints=list(range(int(binvar_min),int(binvar_max)+1))
-		if binvar_max-binvar_min <=binsize:
-			nbins=1
-		else:
-			nbins=int((binvar_max-binvar_min)/binsize)
-		bin_arrays=np.array_split(binvar_ints,nbins)
-		bins=pd.IntervalIndex.from_tuples([(i[0],i[-1]) for i in bin_arrays],closed='both')
-		pv=pv.assign(row_bins=pd.cut(df[rows],bins,include_lowest=True))
-		pv=pv[cols+vals+['row_bins']]
-		pv.rename(columns={"row_bins": rows})
-		pv['row_bins']=pv['row_bins'].astype('str')
-		pv['row_bins']=pv['row_bins'].apply(interval_to_str)
-		rows='row_bins'
-	#pivot
-	
-	
-	if len(vals)==1:
-		vals=vals[0]
-		split_cells=False
+	if len(pv)==0:
+		
+		html="<table border=\"1\"><tr><td>No results.</td></tr></table>"
+		
 	else:
-		split_cells=True
 	
-	pv=pv.pivot_table(
-		columns=cols,
-		index=rows,
-		values=vals,
-		aggfunc="sum"
-	)
-	
-	#if we're doing split cells
-	#pandas puts the values on top -- flip it to get split cells
-	if split_cells:
-		cl=len(cols)
-		if cl==1:
-			pv=pv.swaplevel(0,len(cols),axis=1).sort_index(axis=1)
-		elif cl==2:
-			#there's got. to be. a better. way.
-			pv=pv.swaplevel(0,1,axis=1).sort_index(axis=1)
-			pv=pv.swaplevel(1,2,axis=1).sort_index(axis=1)
-	
-	pv=pv.fillna(0)
-	html=pv.to_html(index_names=False)
-	html=re.sub('\\n\s+','',html)
+		pv=pv.fillna(0)
+		
+		#force ints
+		for val in vals:
+			pv[val]=pv[val].astype('int')
+		
+		#handle a duplicate varname request like
+		#rows=['nation__name'],cols=['nation__name']
+		#which is dumb, because who wants a diagonal matrix???
+		duplicate_indices=[i for i in cols if i in rows]
+		c=1
+		for duplicate_index in duplicate_indices:
+			duplicate_position=cols.index(duplicate_index)
+			pv=eval(f'pv.assign(duplicate_col_{c}=pv[duplicate_index])')
+			cols[duplicate_position]=f'duplicate_col_{c}'
+			c+=1
+		
+		#if we are binning, then rows should only have one varname
+		#and that var should be numeric
+		if binsize is not None:
+			rows=rows[0]
+			binsize=int(binsize)
+			pv[rows]=pv[rows].astype('int')
+			binvar_min=pv[rows].min()
+			binvar_max=pv[rows].max()
+			binvar_ints=list(range(int(binvar_min),int(binvar_max)+1))
+			if binvar_max-binvar_min <=binsize:
+				nbins=1
+			else:
+				nbins=int((binvar_max-binvar_min)/binsize)
+			bin_arrays=np.array_split(binvar_ints,nbins)
+			bins=pd.IntervalIndex.from_tuples([(i[0],i[-1]) for i in bin_arrays],closed='both')
+			pv=pv.assign(row_bins=pd.cut(df[rows],bins,include_lowest=True))
+			pv=pv[cols+vals+['row_bins']]
+			pv.rename(columns={"row_bins": rows})
+			pv['row_bins']=pv['row_bins'].astype('str')
+			pv['row_bins']=pv['row_bins'].apply(interval_to_str)
+			rows='row_bins'
+		#pivot
+		
+		
+		if len(vals)==1:
+			vals=vals[0]
+			split_cells=False
+		else:
+			split_cells=True
+		
+		pv=pv.pivot_table(
+			columns=cols,
+			index=rows,
+			values=vals,
+			aggfunc="sum"
+		)
+		
+		#if we're doing split cells
+		#pandas puts the values on top -- flip it to get split cells
+		if split_cells:
+			cl=len(cols)
+			if cl==1:
+				pv=pv.swaplevel(0,len(cols),axis=1).sort_index(axis=1)
+			elif cl==2:
+				#there's got. to be. a better. way.
+				pv=pv.swaplevel(0,1,axis=1).sort_index(axis=1)
+				pv=pv.swaplevel(1,2,axis=1).sort_index(axis=1)
+		
+		pv=pv.fillna(0)
+		html=pv.to_html(index_names=False)
+		html=re.sub('\\n\s+','',html)
 	return json.dumps(
 		{
 			"data":html


### PR DESCRIPTION


This PR is intended for deployment on staging only.

It addresses the following bugs:

    IIIF manifests were ill-formed when they had linked entities
    The assessments list endpoint needed to be turned on for the voyages-stats engine to pull its data structure
    The administrative interface was not allowing editors to create sources without filling in a few unnecessary fields
    The assessments crosstabs endpoint (which produces the data table) needed to be transformed into an HTML rather than a JSON dump because the table component we have been using, AG Grid, requires an expensive license to turn on row groupings
    Potentially -- if I can get another push up quickly -- add backoff on iiif_generate_manifests script to handle 429 and other errors (I thought I'd done that already, but it seems not, apologies)

Post-deployment tasks, in this order:

    @derekjkeller Clear the redis cache (this should be scripted eventually for all deployments)
    @JohnMulligan Set the has_published_manifest field to False for all OMNO sources (because they have linked entities)
    @JohnMulligan or @derekjkeller Run the iiif_generate_manifests command, with skip-existing=True
    @JohnMulligan or @derekjkeller clear the redis cache once more

Together, steps 2 and 3 will allow for only the problematic manifests to be regenerated.
