### PR TITLE
May 22

### DIFF
--- a/src/api/document/serializers.py
+++ b/src/api/document/serializers.py
@@ -303,4 +303,5 @@ class DocumentSearchSerializer(serializers.Serializer):
 	bib=serializers.CharField(required=False,allow_null=True)
 	enslavers=serializers.ListField(child=serializers.CharField(),required=False,allow_null=True)
 	voyageIds=serializers.ListField(child=serializers.IntegerField(),required=False,allow_null=True)
+	global_search=serializers.CharField(required=False,allow_null=True)
 

--- a/src/api/voyage/views.py
+++ b/src/api/voyage/views.py
@@ -157,7 +157,7 @@ class VoyageDownload(generics.GenericAPIView):
 			
 			#SAVE THIS NEW RESPONSE TO THE REDIS CACHE
 			if USE_REDIS_CACHE:
-				redis_cache.set(hashed,json.dumps(resp))			
+				redis_cache.set(hashed,resp)
 
 		else:
 			if DEBUG:


### PR DESCRIPTION
## Summary

- Fixed: Global search arg was not passed to documents gallery
- Fixed: Voyage results downloads was broken when redis caching was enabled
- Fixed (iiif files): links to entities (voyages, enslaved people, enslavers) were pointing to api-dev instead of app-dev

## Deployment Instructions

1. Please only deploy to `app-dev`
2. Please replace the iiif manifests in app-dev with those in the google drive folder. The filename is iiif_manifests-dev.zip

## Testing Performed

TK

## Ready to Merge?

TK

PRs without this comment will not be considered for merging.
