### PR TITLE
May 22

### DIFF
--- a/src/api/document/serializers.py
+++ b/src/api/document/serializers.py
@@ -303,4 +303,5 @@ class DocumentSearchSerializer(serializers.Serializer):
 	bib=serializers.CharField(required=False,allow_null=True)
 	enslavers=serializers.ListField(child=serializers.CharField(),required=False,allow_null=True)
 	voyageIds=serializers.ListField(child=serializers.IntegerField(),required=False,allow_null=True)
+	global_search=serializers.CharField(required=False,allow_null=True)
 

--- a/src/api/voyage/views.py
+++ b/src/api/voyage/views.py
@@ -157,7 +157,7 @@ class VoyageDownload(generics.GenericAPIView):
 			
 			#SAVE THIS NEW RESPONSE TO THE REDIS CACHE
 			if USE_REDIS_CACHE:
-				redis_cache.set(hashed,json.dumps(resp))			
+				redis_cache.set(hashed,resp)
 
 		else:
 			if DEBUG:


### PR DESCRIPTION
## Summary

- Fixed: Global search arg was not passed to documents gallery
- Fixed: Voyage results downloads was broken when redis caching was enabled
- Fixed (iiif files): links to entities (voyages, enslaved people, enslavers) were pointing to api-dev instead of app-dev

## Deployment Instructions

1. Please only deploy to `app-dev`
2. Please replace the iiif manifests in app-dev with those in the google drive folder. The filename is iiif_manifests-dev.zip

## Testing Performed

docker container prune -f  
docker image prune -f
docker network prune -f     
docker image rm -f $(docker images -a -q)
docker compose up --build -d voyages-mysql voyages-api voyages-adminer voyages-solr
docker exec -i voyages-mysql mysql -uroot -pvoyages voyages_api < data/voyages_prod.sql
docker exec -i voyages-mysql mysql -uvoyages -pvoyages -e "select * from voyages_api.voyage_voyage limit 1"
docker exec -i voyages-api bash -c 'python3 manage.py collectstatic --noinput'
docker exec -i voyages-api bash -c 'python3 manage.py migrate'
docker exec -i voyages-solr solr create_core -c voyages -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c enslavers -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c enslaved -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c blog -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c sources -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c autocomplete_source_titles -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c autocomplete_ship_names -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c autocomplete_enslaved_names -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c autocomplete_enslaver_aliases -d /srv/voyages/solr
docker exec -i voyages-api bash -c 'python3 manage.py rebuild_indices'
docker compose up --build -d voyages-geo-networks voyages-people-networks voyages-stats
