### PR TITLE
Minor bug fixes based on post-July 24 feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 data/*
 !data/empty
 
+src/api/voyages3/google_auth.json
+
 src/api/static/*
 !src/api/static/empty
 src/api/common/static/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The following notes provide an overview of how to install and run the SV API project, which is a restructuring of SlaveVoyages.org to bring it closer to a true microservices model.
 
-For notes on the project structure, see the [Project Structure readme file](PROJECT_STRUCTURE.md)
+For notes on the project structure, see the [Project Structure readme file](src/api/README.md)
 
 For a Swagger UI presentation of the API documentation's generic public endpoints, go to the root url of the endpoint:
 
@@ -68,6 +68,7 @@ Copy the default config files for each app component.
 
 ```bash
 local:~/Projects/voyages-api$ cp src/api/voyages3/localsettings.py{-default,}
+local:~/Projects/voyages-api$ cp src/api/voyages3/google_auth.json{-example,}
 local:~/Projects/voyages-api$ cp src/geo-networks/localsettings.py{-default,}
 local:~/Projects/voyages-api$ cp src/people-networks/localsettings.py{-default,}
 local:~/Projects/voyages-api$ cp src/stats/localsettings.py{-default,}
@@ -75,6 +76,8 @@ local:~/Projects/voyages-api$ cp src/stats/localsettings.py{-default,}
 
 Download the latest database dump from the Google Drive project share and
 expand into the `data/` directory. Rename the expanded file to `data/voyages_prod.sql`.
+
+*Optional*: Add the correct credentials to the `src/api/voyages3/google_auth.json` file in order to enable automatic blog translations.
 
 Build the API containers. The component containers must be built separately.
 

--- a/src/api/blog/apps.py
+++ b/src/api/blog/apps.py
@@ -2,5 +2,7 @@ from django.apps import AppConfig
 
 
 class BlogConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'blog'
+	default_auto_field = 'django.db.models.BigAutoField'
+	name = 'blog'
+	def ready(self):        
+		import blog.signals

--- a/src/api/blog/signals.py
+++ b/src/api/blog/signals.py
@@ -1,0 +1,94 @@
+from django.conf import settings
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from .models import Post, PUBLISH_STATUS
+import json
+from django.utils.text import slugify
+
+from django.db import transaction
+
+#import os
+#os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "/voyages.apps.blog/google_auth.json"
+
+
+
+SOURCE_LANGUAGE = "en"
+
+def on_transaction_commit(func):
+    def inner(*args, **kwargs):
+        transaction.on_commit(lambda: func(*args, **kwargs))
+
+    return inner
+
+
+@receiver(post_save, sender=Post)
+@on_transaction_commit
+def post_saved(sender, instance, **kwargs):
+    
+    if instance.status == PUBLISH_STATUS and instance.language == SOURCE_LANGUAGE:
+        
+        for lang_code, _ in settings.LANGUAGES:
+            if lang_code != SOURCE_LANGUAGE:
+                # First check if the target language already has a translation.
+                count = Post.objects.filter(slug=instance.slug, language=lang_code).count()
+                if count > 0:
+                    continue
+                
+
+                clone = Post.objects.get(pk=instance.pk)
+
+                authors = clone.authors.all()
+                tags = clone.tags.all()
+
+                clone.pk = None
+
+              
+                if not clone.title in [None, '']:
+                    clone.title = translate_text(lang_code, instance.title)
+
+                if not clone.subtitle in [None, '']:
+                    clone.subtitle = translate_text(lang_code, instance.subtitle)
+
+                if not clone.content in [None, '']:
+                    clone.content = translate_text(lang_code, instance.content)
+
+                clone.language = lang_code
+
+                clone.save()                
+                
+                clone.authors.set(authors)
+                clone.tags.set(tags)
+
+
+
+                
+    
+
+def translate_text(target, text):
+    """Translates text into the target language.
+
+    Target must be an ISO 639-1 language code.
+    See https://g.co/cloud/translate/v2/translate-reference#supported_languages
+    """
+    
+    from google.cloud import translate_v2 as translate
+    
+    translate_client = translate.Client.from_service_account_json(r"voyages3/google_auth.json")
+
+    #translate_client = translate.Client()
+
+
+    if isinstance(text, bytes):
+    	text = text.decode("utf-8")
+    
+
+    
+    # Text can also be a sequence of strings, in which case this method
+    # will return a sequence of results for each text.
+    #result = translate_client.translate(text, target_language=target)
+    result = translate_client.translate(text, target_language=target)
+
+   
+
+    return result["translatedText"]

--- a/src/api/blog/views.py
+++ b/src/api/blog/views.py
@@ -49,50 +49,50 @@ class PostList(generics.GenericAPIView):
 			return JsonResponse(serialized_req.errors,status=400)
 
 		#AND ATTEMPT TO RETRIEVE A REDIS-CACHED RESPONSE
-		if USE_REDIS_CACHE:
-			srd=serialized_req.data
-			hashdict={
-				'req_name':str(self.request),
-				'req_data':srd
-			}
-			hashed=hashlib.sha256(
-				json.dumps(
-					hashdict,
-					sort_keys=True,
-					indent=1
-				).encode('utf-8')
-			).hexdigest()
-			cached_response = redis_cache.get(hashed)
-		else:
-			cached_response=None
+# 		if USE_REDIS_CACHE:
+# 			srd=serialized_req.data
+# 			hashdict={
+# 				'req_name':str(self.request),
+# 				'req_data':srd
+# 			}
+# 			hashed=hashlib.sha256(
+# 				json.dumps(
+# 					hashdict,
+# 					sort_keys=True,
+# 					indent=1
+# 				).encode('utf-8')
+# 			).hexdigest()
+# 			cached_response = redis_cache.get(hashed)
+# 		else:
+# 			cached_response=None
 
 		#RUN THE QUERY IF NOVEL, RETRIEVE IT IF CACHED
-		if cached_response is None:
+# 		if cached_response is None:
 			#FILTER THE POSTS BASED ON THE REQUEST'S FILTER OBJECT
-			queryset=Post.objects.all()
-			results,results_count,page,page_size,error_messages=post_req(
-				queryset,
-				self,
-				request,
-				Post_options,
-				auto_prefetch=True,
-				paginate=True
-			)
-			
-			if error_messages:
-				return(JsonResponse(error_messages,safe=False,status=400))
+		queryset=Post.objects.all()
+		results,results_count,page,page_size,error_messages=post_req(
+			queryset,
+			self,
+			request,
+			Post_options,
+			auto_prefetch=True,
+			paginate=True
+		)
+		
+		if error_messages:
+			return(JsonResponse(error_messages,safe=False,status=400))
 
-			resp=PostListResponseSerializer({
-				'count':results_count,
-				'page':page,
-				'page_size':page_size,
-				'results':results
-			}).data
+		resp=PostListResponseSerializer({
+			'count':results_count,
+			'page':page,
+			'page_size':page_size,
+			'results':results
+		}).data
 			#SAVE THIS NEW RESPONSE TO THE REDIS CACHE
-			if USE_REDIS_CACHE:
-				redis_cache.set(hashed,json.dumps(resp))
-		else:
-			resp=json.loads(cached_response)
+# 			if USE_REDIS_CACHE:
+# 				redis_cache.set(hashed,json.dumps(resp))
+# 		else:
+# 			resp=json.loads(cached_response)
 		
 		if DEBUG:
 			print("Internal Response Time:",time.time()-st,"\n+++++++")

--- a/src/api/common/reqs.py
+++ b/src/api/common/reqs.py
@@ -163,6 +163,7 @@ def post_req(orig_queryset,s,r,options_dict,auto_prefetch=True,paginate=False):
 	if DEBUG:
 		print("PRE FILTER COUNT",orig_queryset.count())
 	
+	
 	#PREFETCH REQUISITE FIELDS
 	prefetch_fields=params.get('selected_fields') or []
 	if prefetch_fields==[] and auto_prefetch:
@@ -270,6 +271,8 @@ def post_req(orig_queryset,s,r,options_dict,auto_prefetch=True,paginate=False):
 		for item in filter_obj:
 			if ids is not None:
 				filtered_queryset=filtered_queryset.filter(id__in=ids)
+				
+			print("--->",item)
 			#construct the django-style search on any related field
 			op=item['op']
 			searchTerm=item["searchTerm"]
@@ -559,6 +562,7 @@ def autocomplete_req(queryset,self,request,options,sourcemodelname):
 		targetmodelname=inverted_autocomplete_basic_index_field_endings[sourcemodelname][varName]
 		fieldtail=re.sub('.*?__','',varName)
 		queryset=eval(f'{targetmodelname}.objects.all()')
+		
 		filtered_queryset,results_count,page,page_size,error_messages=post_req(
 			queryset,
 			self,

--- a/src/api/voyage/serializers.py
+++ b/src/api/voyage/serializers.py
@@ -780,6 +780,7 @@ class VoyageCrossTabRequestSerializer(serializers.Serializer):
 	limit=serializers.IntegerField()
 	order_by=serializers.ListField(child=serializers.CharField(),allow_null=True,required=False)
 	global_search=serializers.CharField(allow_null=True,required=False)
+	filter=VoyageFilterItemSerializer(many=True,allow_null=True,required=False)
 	
 class VoyageCrossTabResponseSerializer(serializers.Serializer):
 	tablestructure=serializers.JSONField()

--- a/src/api/voyage/serializers.py
+++ b/src/api/voyage/serializers.py
@@ -212,6 +212,11 @@ class VoyageSourceSerializer(serializers.ModelSerializer):
 		fields=['short_ref','title','bib','has_published_manifest','zotero_group_id','zotero_item_id']
 	def get_bib(self,instance) -> CharField():
 		raw_bib=instance.bib
+		#strip out paragraph tags injected by zotero
+		if raw_bib is not None:
+			raw_bib=re.sub("</*p.*?>","",raw_bib)
+			raw_bib=re.sub("</*div.*?>","",raw_bib)
+			raw_bib=re.sub("/n"," ",raw_bib)
 		text_refs=[t for t in instance.page_ranges if t is not None]
 		if len(text_refs)>0:
 			return f"{raw_bib}: {', '.join(text_refs)}"

--- a/src/api/voyages3/google_auth.json-example.json
+++ b/src/api/voyages3/google_auth.json-example.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "",
+  "private_key_id": "",
+  "private_key": "",
+  "client_email": "",
+  "client_id": "",
+  "auth_uri": "",
+  "token_uri": "",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": ""
+}


### PR DESCRIPTION
## Summary

- Cleaned up sources bibliographic representation
- Incorporated the legacy blog translation functionality
- Pivot table redis fixed

## Deployment Instructions

Place the `google_auth.json` file (located in the shared drive) into `/src/api/voyages3/` next to `localsettings.py`.

This file has also been added to the gitignore, with an example file being placed in the target folder, and the readme being updated to reflect this extra step.

## Testing Performed

`docker container prune -f
docker image prune -f
docker volume prune -f
docker network prune -f
docker image rm -f $(docker images -a -q)
docker compose up --build -d voyages-mysql voyages-api voyages-adminer voyages-solr
docker exec -i voyages-mysql mysql -uroot -pvoyages voyages_api < data/voyages_prod.sql
docker exec -i voyages-mysql mysql -uvoyages -pvoyages -e "select * from voyages_api.voyage_voyage limit 1"
docker exec -i voyages-api bash -c 'python3 manage.py collectstatic --noinput'
docker exec -i voyages-api bash -c 'python3 manage.py migrate'
docker exec -i voyages-solr solr create_core -c voyages -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c enslavers -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c enslaved -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c blog -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c sources -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c voyagesources -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c enslaversources -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c enslavedsources -d /srv/voyages/solr
docker exec -i voyages-api bash -c 'python3 manage.py rebuild_indices'
docker compose up --build -d voyages-geo-networks voyages-people-networks voyages-stats`

## Ready to Merge?

When you are ready for the Pull Request to be merged, leave a comment on the PR with the following exact text:

```
@derekjkeller This PR is ready to merge.
```

PRs without this comment will not be considered for merging.
