### PR TITLE
Adds gunicorn and command overrides

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.7"
-
 services:
   voyages-mysql:
     image: "mysql:8.0.33-oracle"
@@ -68,6 +66,7 @@ services:
     build:
       context: "./src/api"
       dockerfile: "../../docker/api/Dockerfile"
+    command: ${API_CMD:-}
 
   voyages-stats:
     image: "voyages-stats"
@@ -85,6 +84,7 @@ services:
     build:
       context: "./src/stats"
       dockerfile: "../../docker/stats/Dockerfile"
+    command: ${STATS_CMD:-}
 
   voyages-people-networks:
     image: "voyages-people-networks"
@@ -102,6 +102,7 @@ services:
     build:
       context: "./src/people-networks"
       dockerfile: "../../docker/people-networks/Dockerfile"
+    command: ${PEOPLE_NETWORKS_CMD:-}
 
   voyages-geo-networks:
     image: "voyages-geo-networks"
@@ -119,6 +120,7 @@ services:
     build:
       context: "./src/geo-networks"
       dockerfile: "../../docker/geo-networks/Dockerfile"
+    command: ${GEO_NETWORKS_CMD:-}
 
   voyages-adminer:
     image: "adminer:latest"

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -51,12 +51,6 @@ ENV PATH=/root/.local/bin:$PATH
 COPY --from=build /root/.local /root/.local
 COPY . .
 
-ARG GUNICORN_PORT="8000"
-ARG GUNICORN_OPTS="--reload --workers 3 --threads 2 --worker-class gthread"
+EXPOSE 8000
 
-ENV GUNICORN_PORT=${GUNICORN_PORT}
-ENV GUNICORN_OPTS=${GUNICORN_OPTS}
-
-EXPOSE $GUNICORN_PORT
-
-CMD gunicorn --bind 0.0.0.0:$GUNICORN_PORT $GUNICORN_OPTS voyages3.wsgi
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--reload", "--workers", "3", "--threads", "2", "--worker-class", "gthread", "voyages3.wsgi"]

--- a/docker/geo-networks/Dockerfile
+++ b/docker/geo-networks/Dockerfile
@@ -22,10 +22,6 @@ COPY --from=build /root/.local /root/.local
 
 COPY . .
 
-ARG FLASK_PORT=5005
+EXPOSE 5005
 
-ENV FLASK_PORT=$FLASK_PORT
-
-EXPOSE $FLASK_PORT
-
-CMD flask run --host=0.0.0.0 --port=$FLASK_PORT
+CMD ["flask", "run", "--host=0.0.0.0", "--port=5005"]

--- a/docker/people-networks/Dockerfile
+++ b/docker/people-networks/Dockerfile
@@ -22,10 +22,6 @@ COPY --from=build /root/.local /root/.local
 
 COPY . .
 
-ARG FLASK_PORT=5006
+EXPOSE 5006
 
-ENV FLASK_PORT=$FLASK_PORT
-
-EXPOSE $FLASK_PORT
-
-CMD flask run --host=0.0.0.0 --port=$FLASK_PORT
+CMD ["flask", "run", "--host=0.0.0.0", "--port=5006"]

--- a/docker/stats/Dockerfile
+++ b/docker/stats/Dockerfile
@@ -22,10 +22,6 @@ COPY --from=build /root/.local /root/.local
 
 COPY . .
 
-ARG FLASK_PORT=5000
+EXPOSE 5000
 
-ENV FLASK_PORT=$FLASK_PORT
-
-EXPOSE $FLASK_PORT
-
-CMD flask run --host=0.0.0.0 --port=$FLASK_PORT
+CMD ["flask", "run", "--host=0.0.0.0", "--port=5000"]

--- a/src/geo-networks/requirements.txt
+++ b/src/geo-networks/requirements.txt
@@ -4,6 +4,7 @@ charset-normalizer==3.2.0
 click==8.1.3
 Flask==2.3.2
 Flask-Login==0.6.3
+gunicorn==20.1.0
 idna==3.4
 importlib-metadata==6.7.0
 itsdangerous==2.1.2

--- a/src/people-networks/requirements.txt
+++ b/src/people-networks/requirements.txt
@@ -1,6 +1,7 @@
 blinker==1.6.2
 click==8.1.3
 Flask==2.3.2
+gunicorn==20.1.0
 importlib-metadata==6.7.0
 itsdangerous==2.1.2
 Jinja2==3.1.2

--- a/src/stats/requirements.txt
+++ b/src/stats/requirements.txt
@@ -2,7 +2,7 @@ certifi
 charset-normalizer
 click
 Flask
-gunicorn
+gunicorn==20.1.0
 idna
 itsdangerous
 Jinja2


### PR DESCRIPTION
This commit adds gunicorn for the flask apps and allows a command override for the django and flask apps from docker compose. This is used when hosted remotely -- there is no change in process or behavior for local deployments.

* Adds gunicorn to requirements.txt for each flask app
* Simplifies EXPOSE/CMD in Dockerfiles for the django and flask apps
* Adds ability to override Dockerfile CMD in docker-compose.yml using environment variables
* Removes deprecated version parameter from docker-compose.yml