### PR TITLE
Order by fix

### DIFF
--- a/src/api/common/reqs.py
+++ b/src/api/common/reqs.py
@@ -158,7 +158,35 @@ def global_search(orig_queryset,search_string,core_name=None):
 	results_count=len(ids)
 	return filtered_queryset,results_count
 
+def sort_queryset(filtered_queryset,params,all_fields):
+	st=time.time()
+	order_by=params.get('order_by')
+	if order_by is not None:
+		if DEBUG:
+			print(f"------>ORDER BY: {order_by}")
+		obl=[]
+		for ob in order_by:
+			if ob.startswith('-'):
+				k=ob[1:]
+				ascdesc='asc'
+			else:
+				ascdesc='desc'
+				k=ob
+			if k in all_fields:
+				obl.append(k)
+			else:
+				print(f"key is invalid to sort on: {k}")
+			
+			oblstr=','.join([f"F('{k}').{ascdesc}(nulls_last=True)" for k in obl])
+			
+			qfilterstr=f"filtered_queryset.order_by({oblstr})"
+			filtered_queryset=eval(qfilterstr)			
+	else:
+		filtered_queryset=filtered_queryset.order_by('id')
+	if DEBUG:
+		print(f"ORDER BY TIME: {time.time()-st}")
 
+	return filtered_queryset
 
 def post_req(orig_queryset,s,r,options_dict,auto_prefetch=True,paginate=False):
 	'''
@@ -362,55 +390,19 @@ def post_req(orig_queryset,s,r,options_dict,auto_prefetch=True,paginate=False):
 		
 	
 	# ORDER RESULTS
-	st=time.time()
-	order_by=params.get('order_by')
-	if order_by is not None:
-		if DEBUG:
-			print(f"------>ORDER BY: {order_by}")
-		obl=[]
-		for ob in order_by:
-			if ob.startswith('-'):
-				k=ob[1:]
-				ascdesc='asc'
-			else:
-				ascdesc='desc'
-				k=ob
-			if k in all_fields:
-				obl.append(k)
-			else:
-				print(f"key is invalid to sort on: {k}")
-			
-			oblstr=','.join([f"F('{k}').{ascdesc}(nulls_last=True)" for k in obl])
-			
-			qfilterstr=f"filtered_queryset.order_by({oblstr})"
-			filtered_queryset=eval(qfilterstr)
-			
-	else:
-		filtered_queryset=filtered_queryset.order_by('id')
-	
-	if DEBUG:
-		print(f"ORDER BY TIME: {time.time()-st}")
+	filtered_queryset=sort_queryset(filtered_queryset,params,all_fields)
 	
 	st=time.time()
 	# n.b. ordering on a many related field can create duplicates. we handle this later.
 	## dedupe ordered results (while retaining the order)
 	## https://stackoverflow.com/questions/480214/how-do-i-remove-duplicates-from-a-list-while-preserving-order
 	
-# 	if post_order_by_count>pre_order_by_count:
-	dedupe=True
-# 	else:
-# 		dedupe=False
-		
-	if dedupe:
-		ids=[v[0] for v in filtered_queryset.values_list('id')]
-		ids=list(dict.fromkeys(ids))
-		if DEBUG:
-			print(f"DEDUPE TIME: {time.time()-st}")
+	ids=[v[0] for v in filtered_queryset.values_list('id')]
+	ids=list(dict.fromkeys(ids))
+	if DEBUG:
+		print(f"DEDUPE TIME: {time.time()-st}")
 	
-	if dedupe:
-		results_count=len(ids)
-	else:
-		results_count=filtered_queryset.count()
+	results_count=len(ids)
 		
 	if DEBUG:
 		print("COUNT W/O DUPLICATES:",results_count)
@@ -420,34 +412,34 @@ def post_req(orig_queryset,s,r,options_dict,auto_prefetch=True,paginate=False):
 		page_size=params.get('page_size',10)
 		page=params.get('page',1)
 		print("PAGINATION:",paginate, page_size,page)
+
+		
 		if page<0:
 			page=1
 		page=page-1
 		offset=page*page_size
+		if offset>results_count:
+			offset=0
 		
 		end_idx=offset+page_size
 		if end_idx>=results_count:
 			end_idx=results_count
-		if offset>results_count:
-			results=[]
-		else:
-			if dedupe:
-				page_ids=ids[offset:end_idx]
-				results=orig_queryset.filter(id__in=page_ids)
-			else:
-				results=filtered_queryset[offset:end_idx]
+
+		page_ids=ids[offset:end_idx]
+		results=orig_queryset.filter(id__in=page_ids)
 	else:
-		if dedupe:
-			results=orig_queryset.filter(id__in=ids)
-		else:
-			results=filtered_queryset
+		results=orig_queryset.filter(id__in=ids)
 		page=None
 		page_size=None
 	
 	if DEBUG:
 		print(f"FILTER ON IDS TIME: {time.time()-st}")
 		print(f"FINAL RESULTS COUNT: {results_count}")
-
+	
+	#one last sort -- the dedupe step (id__in=page_ids) breaks the ordering
+	#so you get the right page of results but not necessarily in the right order
+	results=sort_queryset(results,params,all_fields)
+	
 	return results,results_count,page,page_size,error_messages
 
 def getJSONschema(base_obj_name,hierarchical=False,rebuild=False):

--- a/src/api/past/serializers.py
+++ b/src/api/past/serializers.py
@@ -13,6 +13,25 @@ from common.autocomplete_indices import get_all_model_autocomplete_fields
 from past.cross_filter_fields import EnslaverBasicFilterVarNames,EnslavedBasicFilterVarNames
 from django.core.exceptions import ObjectDoesNotExist
 
+
+	
+def pretty_date(month,day,year):
+	month_string_dict={
+		1:"Jan",2:"Feb",3:"Mar",4:"Apr",5:"May",6:"Jun",7:"Jul",8:"Aug",9:"Sep",10:"Oct",11:"Nov",12:"Dec"
+	}
+	if year is not None:
+		if month is not None:
+			month=month_string_dict[month]
+			if day is not None:
+				date=f'{month} {day}, {year}'
+			else:
+				date=f'{month} {year}'
+		else:
+			date=f'{year}'
+	else:
+		date=None
+	return date
+
 #################################### THE BELOW SERIALIZERS ARE USED FOR API REQUEST VALIDATION. SOME ARE JUST THIN WRAPPERS ON THE ABOVE, LIKE THAT FOR PAGINATED LISTS. OTHERS ARE ALMOST ENTIRELY HAND-WRITTEN/HARD-CODED FOR OUR CUSTOMIZED ENDPOINTS LIKE GEOTREEFILTER AND AUTOCOMPLETE, AND WILL HAVE TO BE KEPT IN ALIGNMENT WITH THE MODELS, VIEWS, AND CUSTOM FUNCTIONS THEY INTERACT WITH.
 
 class AnyField(Field):
@@ -339,16 +358,22 @@ class EnslaverIdentitySerializer(serializers.ModelSerializer):
 			voyagestrings.append(voyagestring)
 					
 		return voyagestrings
-
+	
 	def get_birth(self,instance) -> serializers.CharField():
 		birth_place=instance.birth_place
-		birth_year=instance.birth_year
-		return ", ".join([str(i) for i in [birth_place,birth_year] if i is not None])
+		year=instance.birth_year
+		month=instance.birth_month
+		day=instance.birth_day
+		birth_date=pretty_date(month,day,year)
+		return ", ".join([str(i) for i in [birth_place,birth_date] if i is not None])
 	
 	def get_death(self,instance) -> serializers.CharField():
 		death_place=instance.death_place
-		death_year=instance.death_year
-		return ", ".join([str(i) for i in [death_place,death_year] if i is not None])
+		year=instance.death_year
+		month=instance.death_month
+		day=instance.death_day
+		death_date=pretty_date(month,day,year)
+		return ", ".join([str(i) for i in [death_place,death_date] if i is not None])
 
 	class Meta:
 		model=EnslaverIdentity

--- a/src/api/timelapse/views.py
+++ b/src/api/timelapse/views.py
@@ -187,7 +187,6 @@ class VoyageAnimation(generics.GenericAPIView):
 			#VALIDATE THE RESPONSE
 			if r.ok:
 				j=json.loads(r.text)
-				print(j[0])
 				serialized_resp=TimeLapseResponseItemSerializer(data=j,many=True)
 			if not serialized_resp.is_valid():
 				return JsonResponse(serialized_resp.errors,status=500,safe=False)

--- a/src/stats/index_vars.py
+++ b/src/stats/index_vars.py
@@ -56,9 +56,9 @@ big_df={
       "type": "pct",
       "label": "Percentage of captives who died during crossing (IMP)"
     },
-    "voyage_slaves_numbers__percentage_women_among_embarked_slaves": {
+    "voyage_slaves_numbers__percentage_women_among_landed_slaves": {
       "type": "pct",
-      "label": "Percent women"
+      "label": "Percentage of women among landed slaves"
     },
     "voyage_outcome__vessel_captured_outcome__name": {
       "type": "str",
@@ -218,7 +218,7 @@ big_df={
     },
     "voyage_slaves_numbers__percentage_women": {
       "type": "pct",
-      "label": "Percent women"
+      "label": "Percentage women on voyage"
     },
     "voyage_dates__departure_last_place_of_landing_sparsedate": {
       "type": "obj",


### PR DESCRIPTION
## Summary

David Eltis noticed an issue with the enslavers table sort operations. This was the result of a more fundamental issue in the requests functionality. Resolved now.

## Deployment Instructions

Requesting a db dump to patch some data for this push.

## Testing Performed

Typical deployment script and manual testing of functionality.

docker container prune -f
docker image prune -f
docker volume prune -f
docker network prune -f
docker image rm -f $(docker images -a -q)
docker compose up --build -d voyages-mysql voyages-api voyages-adminer voyages-solr
docker exec -i voyages-mysql mysql -uroot -pvoyages voyages_api < data/voyages_prod.sql
docker exec -i voyages-mysql mysql -uvoyages -pvoyages -e "select * from voyages_api.voyage_voyage limit 1"
docker exec -i voyages-api bash -c 'python3 manage.py collectstatic --noinput'
docker exec -i voyages-api bash -c 'python3 manage.py migrate'
docker exec -i voyages-solr solr create_core -c voyages -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c enslavers -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c enslaved -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c blog -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c sources -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c voyagesources -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c enslaversources -d /srv/voyages/solr
docker exec -i voyages-solr solr create_core -c enslavedsources -d /srv/voyages/solr
docker exec -i voyages-api bash -c 'python3 manage.py rebuild_indices'
docker compose up --build -d voyages-geo-networks voyages-people-networks voyages-stats
